### PR TITLE
Fully parse Corrode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,9 @@ It'd be cool if there existed a port of [Corrode, the C to Rust translator writt
 git clone http://github.com/tcr/corrode-but-in-rust --recursive
 ```
 
-This project contains a proof-of-concept cross-compiler from Haskell to Rust which is not designed to be either correct or generalizable. Instead, it's tailored for these libraries, each written in a conventional programming style. I expect the conversion to go like this:
+This project contains a proof-of-concept cross-compiler from Haskell to Rust which is not designed to be either correct or generalizable. Instead, it's tailored for these libraries, each written in a conventional programming style.
 
-* [x] Automate bulk cross-compilation as modules (see the `out/` directory for current status)
-* [x] Write a proof-of-concept parser for Haskell and compilation to Rust
-* [x] Support functions, variables, literals, types
-* [x] Support case statements and guards
-* [ ] Convert instances and data structures correctly
-* [ ] Detect pointfree code and convert it into pointwise
-* [ ] Properly convert $ and . operators
-* [ ] Convert rest of operators into Rust equivalents or fn wrappers
-* [ ] Successfully parse all files (except lexer.x parser.y) (failures currently output as // ERROR)
-* [ ] Find a way to parse flex-based lexer.x and parser.y files and cross-compile them
-* [ ] Switch to *manual* conversion for all remaining edge cases (&str and String conversion, undoing tricky code segments, etc.)
-* [ ] Pass language-c test bench
-* [ ] Pass corrode test bench
-* [ ] Port literate Haskell comments into Rust
-* [ ] Feature-complete
+**[Follow along in the tracking issue.](https://github.com/tcr/corrode-but-in-rust/issues/1)**
 
 ## Status
 

--- a/out/corrode.rs
+++ b/out/corrode.rs
@@ -1,8 +1,944 @@
-// ERROR: cannot yet convert file "./corrode/src/Language/Rust/AST.hs"
+mod Language_Rust_AST {
+    #[derive(Show, Eq)]
+    struct LitIntRepr(DecRepr, OctalRepr, HexRepr);
 
-// ERROR: cannot yet convert file "./corrode/src/Language/Rust/Corrode/C.lhs"
+    #[derive(Show, Eq)]
+    struct Lit(LitByteStr, String, LitByteChar, Char, LitBool, Bool, LitInt, Integer, LitIntRepr, Type, LitFloat, String, Type);
 
-// ERROR: cannot yet convert file "./corrode/src/Language/Rust/Corrode/CFG.lhs"
+    #[derive(Show, Eq)]
+    struct Visibility(Public, Private);
+
+    #[derive(Show, Eq)]
+    struct Mutable(Immutable, Mutable);
+
+    #[derive(Show)]
+    struct Stmt(Stmt, Expr, Let, Mutable, Var, Maybe(Type), Maybe(Expr), StmtItem, Vec<Attribute>, ItemKind);
+
+    #[derive(Show)]
+    struct Block(Block, Vec<Stmt>, Maybe(Expr));
+
+    #[derive(Show)]
+    struct Attribute(Attribute, String);
+
+    #[derive(Show)]
+    struct Item(Item, Vec<Attribute>, Visibility, ItemKind);
+
+    #[derive(Show)]
+    struct FunctionAttribute(UnsafeFn, ExternABI, Maybe(String));
+
+    #[derive(Show)]
+    struct ItemKind(Function, Vec<FunctionAttribute>, String, Vec<(Mutable, Var, Type)>, Type, Block, Static, Mutable, Var, Type, Expr, Struct, String, Vec<(String, Type)>, Extern, Vec<ExternItem>, Use, String, Enum, String, Vec<Enumerator>, CloneImpl, Type);
+
+    #[derive(Show)]
+    struct ExternItem(ExternFn, String, Vec<(Var, Type)>, Bool, Type, ExternStatic, Mutable, Var, Type);
+
+    #[derive(Show)]
+    struct Enumerator(EnumeratorAuto, String, EnumeratorExpr, String, Expr);
+
+    #[derive(Show)]
+    struct Expr(Lit, Lit, Var, Var, Path, Path, Index, Expr, Expr, ArrayExpr, Vec<Expr>, RepeatArray, Expr, Expr, StructExpr, String, Vec<(String, Expr)>, Maybe(Expr), Call, Expr, Vec<Expr>, MethodCall, Expr, Var, Vec<Expr>, Lambda, Vec<Var>, Expr, Member, Expr, Var, BlockExpr, Block, UnsafeExpr, Block, IfThenElse, Expr, Block, Block, Loop, Maybe(Lifetime), Block, While, Maybe(Lifetime), Expr, Block, For, Maybe(Lifetime), Var, Expr, Block, Break, Maybe(Lifetime), Continue, Maybe(Lifetime), Return, Maybe(Expr), Neg, Expr, Deref, Expr, Not, Expr, Borrow, Mutable, Expr, Cast, Expr, Type, Mul, Expr, Expr, Div, Expr, Expr, Mod, Expr, Expr, Add, Expr, Expr, Sub, Expr, Expr, ShiftL, Expr, Expr, ShiftR, Expr, Expr, And, Expr, Expr, Xor, Expr, Expr, Or, Expr, Expr, CmpLT, Expr, Expr, CmpGT, Expr, Expr, CmpLE, Expr, Expr, CmpGE, Expr, Expr, CmpEQ, Expr, Expr, CmpNE, Expr, Expr, LAnd, Expr, Expr, LOr, Expr, Expr, Range, Expr, Expr, Assign, Expr, AssignOp, Expr);
+
+    #[derive(Show)]
+    struct AssignOp(:=, :+=, :-=, :*=, :/=, :%=, :&=, :|=, :^=, :<<=, :>>=);
+
+    #[derive(Show)]
+    struct ExprPosition(TopExpr, LeftExpr, RightExpr);
+
+    fn pPrintBlock(__0: Doc, __1: Block) -> Doc {
+        match (__0, __1) {
+            pre, Block([], e) => { sep(vec![<+>(pre, text("{".to_string())), nest(4, (maybe(empty, pPrint, e))), text("}".to_string())]) },
+            pre, Block(ss, e) => { <+>(pre, $+$(text("{".to_string()), $+$(nest(4, (vcat((++(map(pPrint, ss), vec![maybe(empty, pPrint, e)]))))), text("}".to_string())))) },
+        }
+    }
+
+}
+
+mod Language_Rust_Corrode_C {
+    struct FunctionContext(FunctionContext, { /* struct def */ });
+
+    struct Output(Output, { /* struct def */ });
+
+    struct GlobalState(GlobalState, { /* struct def */ });
+
+    struct EnvState(EnvState, { /* struct def */ });
+
+    struct Initializer(Initializer, Maybe(Rust.Expr), IntMap.IntMap(Initializer));
+
+    #[derive(Show)]
+    struct Designator(Base, CType, From, CType, isize, Vec<CType>, Designator);
+
+    struct OuterLabels(OuterLabels, { /* struct def */ });
+
+    struct Result(Result, { /* struct def */ });
+
+    #[derive(Show, Eq)]
+    struct Signed(Signed, Unsigned);
+
+    #[derive(Show, Eq)]
+    struct IntWidth(BitWidth, isize, WordWidth);
+
+    #[derive(Show)]
+    struct CType(IsBool, IsInt, Signed, IntWidth, IsFloat, isize, IsVoid, IsFunc, CType, Vec<(Maybe((Rust.Mutable, Ident)), CType)>, Bool, IsPtr, Rust.Mutable, CType, IsArray, Rust.Mutable, isize, CType, IsStruct, String, Vec<(String, CType)>, IsEnum, String, IsIncomplete, Ident);
+
+    struct IntermediateType(IntermediateType, { /* struct def */ });
+
+    fn addExternIdent(ident: Ident, deferred: EnvMonad(s, IntermediateType), mkItem: fn(String) -> fn((Rust.Mutable, CType)) -> Rust.ExternItem) -> EnvMonad(s, ()) {
+        {
+
+        }
+    }
+
+    fn addSwitchCase(condition: Maybe(CExpr), body: CStat, next: CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result)))) -> CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result))) {
+        {
+
+        }
+    }
+
+    fn addSymbolIdent(ident: Ident, (mut, ty): (Rust.Mutable, CType)) -> EnvMonad(s, String) {
+        {
+
+        }
+    }
+
+    fn addSymbolIdentAction(ident: Ident, action: EnvMonad(s, Result)) -> EnvMonad(s, ()) {
+        lift({
+
+            })
+    }
+
+    fn addTagIdent(ident: Ident, ty: EnvMonad(s, CType)) -> EnvMonad(s, ()) {
+        lift({
+
+            })
+    }
+
+    fn addTypedefIdent(ident: Ident, ty: EnvMonad(s, IntermediateType)) -> EnvMonad(s, ()) {
+        lift({
+
+            })
+    }
+
+    fn applyRenames(ident: Ident) -> String {
+        match identToString(ident) {
+                "final" => { "final_".to_string() },
+                "fn" => { "fn_".to_string() },
+                "in" => { "in_".to_string() },
+                "let" => { "let_".to_string() },
+                "main" => { "_c_main".to_string() },
+                "match" => { "match_".to_string() },
+                "mod" => { "mod_".to_string() },
+                "proc" => { "proc_".to_string() },
+                "type" => { "type_".to_string() },
+                "where" => { "where_".to_string() },
+                name => { name },
+            }
+    }
+
+    fn badSource(node: node, msg: String) -> EnvMonad(s, a) {
+        noTranslation(node, (++("illegal ".to_string(), ++(msg, "; check whether a real C compiler accepts this".to_string()))))
+    }
+
+    fn baseTypeOf(specs: Vec<CDeclSpec>) -> EnvMonad(s, (Maybe(CStorageSpec), EnvMonad(s, IntermediateType))) {
+        {
+
+        }
+    }
+
+    fn binop(expr: CExpr, op: CBinaryOp, lhs: Result, rhs: Result) -> EnvMonad(s, Result) {
+        fmap(wrapping)(match op {
+                    CMulOp => { promote(expr, Rust.Mul, lhs, rhs) },
+                    CDivOp => { promote(expr, Rust.Div, lhs, rhs) },
+                    CRmdOp => { promote(expr, Rust.Mod, lhs, rhs) },
+                    CAddOp => { match (toPtr(lhs), toPtr(rhs)) {
+                            (Just(ptr), _) => { return((offset(ptr, rhs))) },
+                            (_, Just(ptr)) => { return((offset(ptr, lhs))) },
+                            _ => { promote(expr, Rust.Add, lhs, rhs) },
+                        } },
+                    CSubOp => { match (toPtr(lhs), toPtr(rhs)) {
+                            (Just(lhs'), Just(rhs')) => { {
+
+                            } },
+                            (Just(ptr), _) => { return(ptr, hashmap! {
+                                "result" => Rust.MethodCall((result(ptr)), (Rust.VarName("offset".to_string())), vec![Rust.Neg((castTo((IsInt(Signed, WordWidth)), rhs)))])
+                                }) },
+                            _ => { promote(expr, Rust.Sub, lhs, rhs) },
+                        } },
+                    CShlOp => { shift(Rust.ShiftL) },
+                    CShrOp => { shift(Rust.ShiftR) },
+                    CLeOp => { comparison(Rust.CmpLT) },
+                    CGrOp => { comparison(Rust.CmpGT) },
+                    CLeqOp => { comparison(Rust.CmpLE) },
+                    CGeqOp => { comparison(Rust.CmpGE) },
+                    CEqOp => { comparison(Rust.CmpEQ) },
+                    CNeqOp => { comparison(Rust.CmpNE) },
+                    CAndOp => { promote(expr, Rust.And, lhs, rhs) },
+                    CXorOp => { promote(expr, Rust.Xor, lhs, rhs) },
+                    COrOp => { promote(expr, Rust.Or, lhs, rhs) },
+                    CLndOp => { return(Result, hashmap! {
+                        "resultType" => IsBool,
+                        "resultMutable" => Rust.Immutable,
+                        "result" => Rust.LAnd((toBool(lhs)), (toBool(rhs)))
+                        }) },
+                    CLorOp => { return(Result, hashmap! {
+                        "resultType" => IsBool,
+                        "resultMutable" => Rust.Immutable,
+                        "result" => Rust.LOr((toBool(lhs)), (toBool(rhs)))
+                        }) },
+                })
+    }
+
+    fn bitWidth(__0: isize, __1: IntWidth) -> isize {
+        match (__0, __1) {
+            wordWidth, WordWidth => { wordWidth },
+            _, BitWidth(w) => { w },
+        }
+    }
+
+    fn blockToStatements(Rust.Block(stmts, mexpr): Rust.Block) -> Vec<Rust.Stmt> {
+        match mexpr {
+                Just, expr => { ++(stmts, exprToStatements(expr)) },
+                Nothing => { stmts },
+            }
+    }
+
+    fn castTo(__0: CType, __1: Result) -> Rust.Expr {
+        match (__0, __1) {
+            target, Result({ .. }) => { castTo(target, Result, hashmap! {
+                "resultType" => IsPtr(mut, el),
+                "resultMutable" => Rust.Immutable,
+                "result" => Rust.MethodCall(source, (Rust.VarName(method)), vec![])
+                }) },
+            IsBool, source => { toBool(source) },
+            target, <todo>, IsInt({ .. }), Result({ .. }) => { Rust.Lit((Rust.LitInt(n, repr, (toRustType(target))))) },
+            IsInt(Signed, w), Result({ .. }) => { Rust.Neg((Rust.Lit((Rust.LitInt(n, repr, (toRustType((IsInt(Signed, w))))))))) },
+            target, source => { Rust.Cast((result(source)), (toRustType(target))) },
+        }
+    }
+
+    fn cfgToRust(_node: node, build: CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result)))) -> EnvMonad(s, Vec<Rust.Stmt>) {
+        {
+
+        }
+    }
+
+    fn charType() -> CType {
+        IsInt(Unsigned, (BitWidth(8)))
+    }
+
+    fn compatibleInitializer(__0: CType, __1: CType) -> Bool {
+        match (__0, __1) {
+            IsStruct(name1, _), IsStruct(name2, _) => { ==(name1, name2) },
+            IsStruct, { .. }, _ => { False },
+            _, IsStruct, { .. } => { False },
+            _, _ => { True },
+        }
+    }
+
+    fn compatiblePtr(__0: CType, __1: CType) -> CType {
+        match (__0, __1) {
+            IsPtr(_, IsVoid), b => { b },
+            IsArray(mut, _, el), b => { compatiblePtr((IsPtr(mut, el)), b) },
+            a, IsPtr(_, IsVoid) => { a },
+            a, IsArray(mut, _, el) => { compatiblePtr(a, (IsPtr(mut, el))) },
+            IsPtr(m1, a), IsPtr(m2, b) => { IsPtr((leastMutable(m1, m2)), (compatiblePtr(a, b))) },
+            _, _ => { IsVoid },
+        }
+    }
+
+    fn completeType(__0: CType, __1: EnvMonad(s, CType)) -> EnvMonad(s, CType) {
+        match (__0, __1, __2) {
+            orig, <todo>, IsIncomplete(ident) => { {
+
+            } },
+            ty => { return(ty) },
+        }
+    }
+
+    fn compound(expr: CExpr, returnOld: Bool, demand: Bool, op: CAssignOp, lhs: Result, rhs: Result) -> EnvMonad(s, Result) {
+        {
+
+        }
+    }
+
+    fn derivedDeferredTypeOf(deferred: EnvMonad(s, IntermediateType), declr: CDeclr, <todo>: Vec<CDecl>, CDeclr(_, derived, _, _, _): EnvMonad(s, EnvMonad(s, IntermediateType))) -> EnvMonad(s, EnvMonad(s, IntermediateType)) {
+        {
+
+        }
+    }
+
+    fn derivedTypeOf(deferred: EnvMonad(s, IntermediateType), declr: CDeclr) -> EnvMonad(s, IntermediateType) {
+        join((derivedDeferredTypeOf(deferred, declr, vec![])))
+    }
+
+    fn designatorType(__0: Designator) -> CType {
+        match (__0) {
+            Base(ty) => { ty },
+            From(ty, _, _, _) => { ty },
+        }
+    }
+
+    fn emitIncomplete(kind: ItemKind, ident: Ident) -> EnvMonad(s, CType) {
+        {
+
+        }
+    }
+
+    fn emitItems(items: Vec<Rust.Item>) -> EnvMonad(s, ()) {
+        lift(tell(mempty, hashmap! {
+                "outputItems" => items
+                }))
+    }
+
+    fn enumReprType() -> CType {
+        IsInt(Signed, (BitWidth(32)))
+    }
+
+    fn exprToStatements(__0: Rust.Expr) -> Vec<Rust.Stmt> {
+        match (__0) {
+            Rust.IfThenElse(c, t, f) => { vec![Rust.Stmt((Rust.IfThenElse(c, (extractExpr(t)), (extractExpr(f)))))] },
+            Rust.BlockExpr(b) => { blockToStatements(b) },
+            e => { vec![Rust.Stmt(e)] },
+        }
+    }
+
+    fn getSwitchCases(expr: CExpr) -> CSourceBuildCFGT(s, (a, SwitchCases)) {
+        mapBuildCFGT(wrap)
+    }
+
+    fn getSwitchExpression(stmt: CStat) -> CSourceBuildCFGT(s, CExpr) {
+        {
+
+        }
+    }
+
+    fn getSymbolIdent(ident: Ident) -> EnvMonad(s, Maybe(Result)) {
+        {
+
+        }
+    }
+
+    fn getTagIdent(ident: Ident) -> EnvMonad(s, Maybe(EnvMonad(s, CType))) {
+        lift({
+
+            })
+    }
+
+    fn getTypedefIdent(ident: Ident) -> EnvMonad(s, (String, Maybe(EnvMonad(s, IntermediateType)))) {
+        lift({
+
+            })
+    }
+
+    fn gotoLabel(ident: Ident) -> CSourceBuildCFGT(s, Label) {
+        {
+
+        }
+    }
+
+    fn intPromote(__0: CType) -> CType {
+        match (__0) {
+            IsBool => { IsInt(Signed, (BitWidth(32))) },
+            IsEnum(_) => { enumReprType },
+            x => { x },
+        }
+    }
+
+    fn integerConversionRank(__0: IntWidth, __1: IntWidth) -> Maybe(Ordering) {
+        match (__0, __1) {
+            BitWidth(a), BitWidth(b) => { Just((compare(a, b))) },
+            WordWidth, WordWidth => { Just(EQ) },
+            _, _ => { Nothing },
+        }
+    }
+
+    fn interpretBlockItem(__0: CBlockItem, __1: CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result)))) -> CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result))) {
+        match (__0, __1) {
+            CBlockStmt(stmt), next => { interpretStatement(stmt, next) },
+            CBlockDecl(decl), next => { {
+
+            } },
+            item, _ => { lift(lift((unimplemented(item)))) },
+        }
+    }
+
+    fn interpretConstExpr(__0: CExpr) -> EnvMonad(s, Integer) {
+        match (__0) {
+            CConst(CIntConst(CInteger(v, _, _), _)) => { return(v) },
+            expr => { unimplemented(expr) },
+        }
+    }
+
+    fn interpretDeclarations(__0: MakeBinding(s, b), __1: CDecl, __2: EnvMonad(s, Vec<b>)) -> EnvMonad(s, Vec<b>) {
+        match (__0, __1, __2, __3) {
+            (fromItem, makeBinding), declaration, <todo>, CDecl(specs, decls, _) => { {
+
+            } },
+            _, node, <todo>, CStaticAssert({ .. }) => { unimplemented(node) },
+        }
+    }
+
+    fn interpretExpr(__0: Bool, __1: CExpr) -> EnvMonad(s, Result) {
+        match (__0, __1) {
+            demand, CComma(exprs, _) => { {
+
+            } },
+            demand, expr, <todo>, CAssign(op, lhs, rhs, _) => { {
+
+            } },
+            demand, expr, <todo>, CCond(c, Just(t), f, _) => { {
+
+            } },
+            _, expr, <todo>, CBinary(op, lhs, rhs, _) => { {
+
+            } },
+            _, CCast(decl, expr, _) => { {
+
+            } },
+            demand, node, <todo>, CUnary(op, expr, _) => { match op {
+                    CPreIncOp => { incdec(False, CAddAssOp) },
+                    CPreDecOp => { incdec(False, CSubAssOp) },
+                    CPostIncOp => { incdec(True, CAddAssOp) },
+                    CPostDecOp => { incdec(True, CSubAssOp) },
+                    CAdrOp => { {
+
+                    } },
+                    CIndOp => { {
+
+                    } },
+                    CPlusOp => { {
+
+                    } },
+                    CMinOp => { fmap(wrapping)(simple(Rust.Neg)) },
+                    CCompOp => { simple(Rust.Not) },
+                    CNegOp => { {
+
+                    } },
+                } },
+            _, CSizeofExpr(e, _) => { {
+
+            } },
+            _, CSizeofType(decl, _) => { {
+
+            } },
+            _, CAlignofExpr(e, _) => { {
+
+            } },
+            _, CAlignofType(decl, _) => { {
+
+            } },
+            _, expr, <todo>, CIndex(lhs, rhs, _) => { {
+
+            } },
+            _, expr, <todo>, CCall(func, args, _) => { {
+
+            } },
+            _, expr, <todo>, CMember(obj, ident, deref, node) => { {
+
+            } },
+            _, expr, <todo>, CVar(ident, _) => { {
+
+            } },
+            _, expr, <todo>, CConst(c) => { match c {
+                    CIntConst, CInteger(v, repr, flags), _ => { Let(in, match allowed_types {
+                            [] => { badSource(expr, "integer (too big)".to_string()) },
+                            ty, :, _ => { return((literalNumber(ty, (Rust.LitInt(v, repr'))))) },
+                        }) },
+                    CFloatConst, CFloat(str), _ => { match span((Operator("notElem")("fF".to_string())), str) {
+                            (v, "") => { return((literalNumber((IsFloat(64)), (Rust.LitFloat(v))))) },
+                            (v, [_]) => { return((literalNumber((IsFloat(32)), (Rust.LitFloat(v))))) },
+                            _ => { badSource(expr, "float".to_string()) },
+                        } },
+                    CCharConst, CChar(ch, False), _ => { return(Result, hashmap! {
+                        "resultType" => charType,
+                        "resultMutable" => Rust.Immutable,
+                        "result" => Rust.Lit((Rust.LitByteChar(ch)))
+                        }) },
+                    CStrConst, CString(str, False), _ => { return(Result, hashmap! {
+                        "resultType" => IsArray(Rust.Immutable, (+(length(str), 1)), charType),
+                        "resultMutable" => Rust.Immutable,
+                        "result" => Rust.Deref((Rust.Lit((Rust.LitByteStr((++(str, "N".to_string())))))))
+                        }) },
+                    _ => { unimplemented(expr) },
+                } },
+            _, CCompoundLit(decl, initials, info) => { {
+
+            } },
+            demand, stat, <todo>, CStatExpr(CCompound([], stmts, _), _) => { scope({
+
+                }) },
+            _, expr => { unimplemented(expr) },
+        }
+    }
+
+    fn interpretFunction(CFunDef(specs, declr, <todo>, CDeclr(mident, _, _, _, _), argtypes, body, _): CFunDef) -> EnvMonad(s, ()) {
+        {
+
+        }
+    }
+
+    fn interpretInitializer(ty: CType, initial: CInit) -> EnvMonad(s, Rust.Expr) {
+        {
+
+        }
+    }
+
+    fn interpretStatement(__0: CStat, __1: CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result)))) -> CSourceBuildCFGT(s, (Vec<Rust.Stmt>, Terminator(Result))) {
+        match (__0, __1) {
+            CLabel(ident, body, _, _), next => { {
+
+            } },
+            stmt, <todo>, CCase(expr, body, node), next => { {
+
+            } },
+            stmt, <todo>, CCases(lower, upper, body, node), next => { {
+
+            } },
+            CDefault(body, _), next => { addSwitchCase(Nothing, body, next) },
+            CExpr(Nothing, _), next => { next },
+            CExpr(Just(expr), _), next => { {
+
+            } },
+            CCompound([], items, _), next => { mapBuildCFGT((mapRWST(scope)))({
+
+                }) },
+            CIf(c, t, mf, _), next => { {
+
+            } },
+            stmt, <todo>, CSwitch(expr, body, node), next => { {
+
+            } },
+            CWhile(c, body, doWhile, _), next => { {
+
+            } },
+            CFor(initial, mcond, mincr, body, _), next => { {
+
+            } },
+            CGoto(ident, _), next => { {
+
+            } },
+            stmt, <todo>, CCont(_), next => { {
+
+            } },
+            stmt, <todo>, CBreak(_), next => { {
+
+            } },
+            stmt, <todo>, CReturn(expr, _), next => { {
+
+            } },
+            stmt, _ => { lift(lift(unimplemented(stmt))) },
+        }
+    }
+
+    fn interpretTranslationUnit(_thisModule: ModuleMap, rewrites: ItemRewrites, CTranslUnit(decls, _): CTranslUnit) -> Either(String, Vec<Rust.Item>) {
+        match err {
+                Left, msg => { Left(msg) },
+                Right, _ => { Right(items') },
+            }
+    }
+
+    fn makeLetBinding() -> MakeBinding(s, Rust.Stmt) {
+        (Rust.StmtItem(vec![]), makeBinding)
+    }
+
+    fn makeStaticBinding() -> MakeBinding(s, Rust.Item) {
+        (Rust.Item(vec![], Rust.Private), makeBinding)
+    }
+
+    fn modifyGlobal(f: fn(GlobalState) -> (GlobalState, a)) -> EnvMonad(s, a) {
+        lift({
+
+            })
+    }
+
+    fn mutable(quals: Vec<CTypeQualifier(a)>) -> Rust.Mutable {
+        if(any, (Lambda), quals, then, Rust.Immutable, else, Rust.Mutable)
+    }
+
+    fn nestedObject(ty: CType, desig: Designator) -> Maybe(Designator) {
+        match designatorType(desig) {
+                IsArray, _, size, el => { Just((From(el, 0, (replicate((-(size, 1)), el)), desig))) },
+            ty' => if compatibleInitializer(ty, ty') { Just(desig) },
+                IsStruct, _, (_, ty')(:, fields) => { nestedObject(ty, (From(ty', 0, (map(snd, fields)), desig))) },
+                _ => { Nothing },
+            }
+    }
+
+    fn nextObject(__0: Designator, __1: CurrentObject) -> CurrentObject {
+        match (__0, __1) {
+            Base, { .. } => { Nothing },
+            From(_, i, ty(:, remaining), base) => { Just((From(ty, (+(i, 1)), remaining, base))) },
+            From(_, _, [], base) => { nextObject(base) },
+        }
+    }
+
+    fn noTranslation(node: node, msg: String) -> EnvMonad(s, a) {
+        throwE(concat(vec![show((posOf(node))), ": ".to_string(), msg, ":\\n".to_string(), render((nest(4, (pretty(node)))))]))
+    }
+
+    fn objectFromDesignators(__0: CType, __1: Vec<CDesignator>) -> EnvMonad(s, CurrentObject) {
+        match (__0, __1) {
+            _, [] => { pure(Nothing) },
+            ty, desigs => { <$>(Just, go(ty, desigs, (Base(ty)))) },
+        }
+    }
+
+    fn promote(node: node, op: fn(Rust.Expr) -> fn(Rust.Expr) -> Rust.Expr, a: Result, b: Result) -> EnvMonad(s, Result) {
+        match usual((resultType(a)), (resultType(b))) {
+                Just, rt => { return(Result, hashmap! {
+                    "resultType" => rt,
+                    "resultMutable" => Rust.Immutable,
+                    "result" => op((castTo(rt, a)), (castTo(rt, b)))
+                    }) },
+                Nothing => { badSource(node)(concat(vec!["arithmetic combination for ".to_string(), show((resultType(a))), " and ".to_string(), show((resultType(b)))])) },
+            }
+    }
+
+    fn promotePtr(node: node, op: fn(Rust.Expr) -> fn(Rust.Expr) -> Rust.Expr, a: Result, b: Result) -> EnvMonad(s, Result) {
+        match (resultType(a), resultType(b)) {
+                (IsArray(_, _, _), _) => { ptrs },
+                (IsPtr(_, _), _) => { ptrs },
+                (_, IsArray(_, _, _)) => { ptrs },
+                (_, IsPtr(_, _)) => { ptrs },
+                _ => { promote(node, op, a, b) },
+            }
+    }
+
+    fn resolveCurrentObject((obj0, prior): (CurrentObject, Initializer), (obj1, cinitial): (CurrentObject, CInit)) -> EnvMonad(s, (CurrentObject, Initializer)) {
+        match mplus(obj1, obj0) {
+                Nothing => { return((Nothing, prior)) },
+                Just, obj => { {
+
+                } },
+            }
+    }
+
+    fn resultToStatements() -> Vec<Rust.Stmt> {
+        (exprToStatements . result)
+    }
+
+    fn runOnce(action: EnvMonad(s, a)) -> EnvMonad(s, EnvMonad(s, a)) {
+        {
+
+        }
+    }
+
+    fn rustAlignOfType(Rust.TypeName(ty): Rust.Type) -> Result {
+        Result(hashmap! {
+            "resultType" => IsInt(Unsigned, WordWidth),
+            "resultMutable" => Rust.Immutable,
+            "result" => Rust.Call((Rust.Var((Rust.VarName((++("::std::mem::align_of::<".to_string(), ++(ty, ">".to_string()))))))), vec![])
+            })
+    }
+
+    fn rustSizeOfType(Rust.TypeName(ty): Rust.Type) -> Result {
+        Result(hashmap! {
+            "resultType" => IsInt(Unsigned, WordWidth),
+            "resultMutable" => Rust.Immutable,
+            "result" => Rust.Call((Rust.Var((Rust.VarName((++("::std::mem::size_of::<".to_string(), ++(ty, ">".to_string()))))))), vec![])
+            })
+    }
+
+    fn scalar(expr: Rust.Expr) -> Initializer {
+        Initializer((Just(expr)), IntMap.empty)
+    }
+
+    fn scope(m: EnvMonad(s, a)) -> EnvMonad(s, a) {
+        {
+
+        }
+    }
+
+    fn setBreak(label: Label) -> CSourceBuildCFGT(s, a) {
+        mapBuildCFGT((local((Lambda(hashmap! {
+                    "onBreak" => Just(label)
+                    })))))
+    }
+
+    fn setContinue(label: Label) -> CSourceBuildCFGT(s, a) {
+        mapBuildCFGT((local((Lambda(hashmap! {
+                    "onContinue" => Just(label)
+                    })))))
+    }
+
+    fn statementsToBlock(__0: Vec<Rust.Stmt>) -> Rust.Block {
+        match (__0) {
+            [Rust.Stmt(Rust.BlockExpr(stmts))] => { stmts },
+            stmts => { Rust.Block(stmts, Nothing) },
+        }
+    }
+
+    fn toBool(__0: Result) -> Rust.Expr {
+        match (__0) {
+            Result({ .. }) => { Rust.Lit((Rust.LitBool(False))) },
+            Result({ .. }) => { Rust.Lit((Rust.LitBool(True))) },
+            Result({ .. }) => { match t {
+                    IsBool => { v },
+                    IsPtr, _, _ => { Rust.Not((Rust.MethodCall(v, (Rust.VarName("is_null".to_string())), vec![]))) },
+                    _ => { Rust.CmpNE(v, 0) },
+                } },
+        }
+    }
+
+    fn toNotBool(__0: Result) -> Rust.Expr {
+        match (__0) {
+            Result({ .. }) => { Rust.Lit((Rust.LitBool(True))) },
+            Result({ .. }) => { Rust.Lit((Rust.LitBool(False))) },
+            Result({ .. }) => { match t {
+                    IsBool => { Rust.Not(v) },
+                    IsPtr, _, _ => { Rust.MethodCall(v, (Rust.VarName("is_null".to_string())), vec![]) },
+                    _ => { Rust.CmpEQ(v, 0) },
+                } },
+        }
+    }
+
+    fn toPtr(__0: Result, __1: Maybe(Result)) -> Maybe(Result) {
+        match (__0, __1, __2) {
+            ptr, <todo>, Result({ .. }) => { Just(ptr, hashmap! {
+                "resultType" => IsPtr(mut, el),
+                "result" => castTo((IsPtr(mut, el)), ptr)
+                }) },
+            ptr, <todo>, Result({ .. }) => { Just(ptr) },
+            _ => { Nothing },
+        }
+    }
+
+    fn toRustRetType(__0: CType) -> Rust.Type {
+        match (__0) {
+            IsVoid => { Rust.TypeName("()".to_string()) },
+            ty => { toRustType(ty) },
+        }
+    }
+
+    fn toRustType(__0: CType) -> Rust.Type {
+        match (__0) {
+            IsBool => { Rust.TypeName("bool".to_string()) },
+            IsInt(s, w) => { Rust.TypeName((:((match s {
+                                Signed => { "\"\"".to_string() },
+                                Unsigned => { "\"\"".to_string() },
+                            }), (match w {
+                                BitWidth, b => { show(b) },
+                                WordWidth => { "size".to_string() },
+                            })))) },
+            IsFloat(w) => { Rust.TypeName((:("\"\"".to_string(), show(w)))) },
+            IsVoid => { Rust.TypeName("::std::os::raw::c_void".to_string()) },
+            IsFunc(retTy, args, variadic) => { Rust.TypeName(concat(vec!["unsafe extern fn(".to_string(), args', ")".to_string(), /=(if(retTy), ++(IsVoid(then, " -> ".to_string()), typename(retTy, else, "".to_string())))])) },
+            IsPtr(mut, to) => { Let },
+            IsArray(_, size, el) => { Rust.TypeName((++("[".to_string(), ++(typename(el), ++("; ".to_string(), ++(show(size), "]".to_string())))))) },
+            IsStruct(name, _fields) => { Rust.TypeName(name) },
+            IsEnum(name) => { Rust.TypeName(name) },
+            IsIncomplete(ident) => { Rust.TypeName((identToString(ident))) },
+        }
+    }
+
+    fn translateInitList(ty: CType, list: CInitList) -> EnvMonad(s, Initializer) {
+        {
+
+        }
+    }
+
+    fn typeName(__0: CDecl, __1: EnvMonad(s, (Rust.Mutable, CType))) -> EnvMonad(s, (Rust.Mutable, CType)) {
+        match (__0, __1, __2) {
+            decl, <todo>, CStaticAssert({ .. }) => { badSource(decl, "static assert in type name ".to_string()) },
+            decl, <todo>, CDecl(spec, declarators, _) => { {
+
+            } },
+        }
+    }
+
+    fn typeToResult(itype: IntermediateType, expr: Rust.Expr) -> Result {
+        Result(hashmap! {
+            "resultType" => typeRep(itype),
+            "resultMutable" => typeMutable(itype),
+            "result" => expr
+            })
+    }
+
+    fn unimplemented(node: node) -> EnvMonad(s, a) {
+        noTranslation(node, "Corrode doesn\'t handle this yet".to_string())
+    }
+
+    fn uniqueName(base: String) -> EnvMonad(s, String) {
+        modifyGlobal(Lambda)
+    }
+
+    fn useForwardRef(ident: Ident) -> EnvMonad(s, ()) {
+        modifyGlobal(Lambda)
+    }
+
+    fn usual(__0: CType, __1: CType) -> Maybe(CType) {
+        match (__0, __1) {
+            IsFloat(aw), IsFloat(bw) => { Just((IsFloat((max(aw, bw))))) },
+            a, <todo>, IsFloat(_), _ => { Just(a) },
+            _, b, <todo>, IsFloat(_) => { Just(b) },
+            origA, origB => { match (intPromote(origA), intPromote(origB)) {
+                (a, b) => if ==(a, b) { Just(a) },
+                    (IsInt(Signed, sw), IsInt(Unsigned, uw)) => { mixedSign(sw, uw) },
+                    (IsInt(Unsigned, uw), IsInt(Signed, sw)) => { mixedSign(sw, uw) },
+                    (IsInt(as, aw), IsInt(_bs, bw)) => { {
+
+                    } },
+                    _ => { Nothing },
+                } },
+        }
+    }
+
+    fn wrapMain(declr: CDeclr, realName: String, argTypes: Vec<CType>) -> EnvMonad(s, ()) {
+        {
+
+        }
+    }
+
+    fn wrapping(__0: Result, __1: Result) -> Result {
+        match (__0, __1, __2) {
+            r, <todo>, Result({ .. }) => { match result(r) {
+                    Rust.Add, lhs, rhs => { r(hashmap! {
+                        "result" => Rust.MethodCall(lhs, (Rust.VarName("wrapping_add".to_string())), vec![rhs])
+                        }) },
+                    Rust.Sub, lhs, rhs => { r(hashmap! {
+                        "result" => Rust.MethodCall(lhs, (Rust.VarName("wrapping_sub".to_string())), vec![rhs])
+                        }) },
+                    Rust.Mul, lhs, rhs => { r(hashmap! {
+                        "result" => Rust.MethodCall(lhs, (Rust.VarName("wrapping_mul".to_string())), vec![rhs])
+                        }) },
+                    Rust.Div, lhs, rhs => { r(hashmap! {
+                        "result" => Rust.MethodCall(lhs, (Rust.VarName("wrapping_div".to_string())), vec![rhs])
+                        }) },
+                    Rust.Mod, lhs, rhs => { r(hashmap! {
+                        "result" => Rust.MethodCall(lhs, (Rust.VarName("wrapping_rem".to_string())), vec![rhs])
+                        }) },
+                    Rust.Neg, e => { r(hashmap! {
+                        "result" => Rust.MethodCall(e, (Rust.VarName("wrapping_neg".to_string())), vec![])
+                        }) },
+                    _ => { r },
+                } },
+            r => { r },
+        }
+    }
+
+}
+
+mod Language_Rust_Corrode_CFG {
+    struct BasicBlock(BasicBlock, s, Terminator(c));
+
+    #[derive(Show)]
+    struct Terminator'(Unreachable, Branch, l, CondBranch, c, l, l);
+
+    struct CFG(CFG, Label, IntMap.IntMap(BasicBlock(s, c)));
+
+    struct BuildState(BuildState, { /* struct def */ });
+
+    #[derive(Show)]
+    struct StructureLabel(GoTo, { /* struct def */ }, ExitTo, { /* struct def */ }, Nested, Vec<Structure(s, c)>);
+
+    #[derive(Show)]
+    struct Structure'(Simple, s, StructureTerminator(s, c), Loop, a, Multiple, IntMap.IntMap(a), a);
+
+    #[derive(Show)]
+    struct Structure(Structure, { /* struct def */ });
+
+    fn addBlock(label: Label, stmt: s, terminator: Terminator(c)) -> BuildCFGT(m, s, c, ()) {
+        {
+
+        }
+    }
+
+    fn buildCFG(root: BuildCFGT(m, s, c, Label)) -> m(CFG(Unordered, s, c)) {
+        {
+
+        }
+    }
+
+    fn depthFirstOrder(CFG(start, blocks): CFG(k, s, c)) -> CFG(DepthFirst, s, c) {
+        CFG(start', blocks')
+    }
+
+    fn flipEdges(edges: IntMap.IntMap(IntSet.IntSet)) -> IntMap.IntMap(IntSet.IntSet) {
+        IntMap.unionsWith(IntSet.union, Dummy)
+    }
+
+    fn hasMultiple() -> Bool {
+        any(((go . structureBody)))
+    }
+
+    fn mapBuildCFGT() -> BuildCFGT(n, s, c, b) {
+        mapStateT
+    }
+
+    fn newLabel() -> BuildCFGT(m, s, c, Label) {
+        {
+
+        }
+    }
+
+    fn outEdges(blocks: IntMap.IntMap(StructureBlock(s, c))) -> IntSet.IntSet {
+        IntSet.difference(IntSet.unions((map(successors)(IntMap.elems(blocks)))), IntMap.keysSet(blocks))
+    }
+
+    fn partitionMembers(a: IntSet.IntSet, b: IntSet.IntSet) -> (IntSet.IntSet, IntSet.IntSet) {
+        (IntSet.intersection(a, b), IntSet.difference(a, b))
+    }
+
+    fn prettyCFG(fmtS: fn(s) -> Doc, fmtC: fn(c) -> Doc, CFG(entry, blocks): CFG(k, s, c)) -> Doc {
+        vcat(:((<>(text("start @".to_string()), text((show(entry))))), blocks'))
+    }
+
+    fn prettyStructure() -> Doc {
+        (vcat . map(go))
+    }
+
+    fn relooper(entries: IntSet.IntSet, blocks: IntMap.IntMap(StructureBlock(s, c))) -> Vec<Structure(s, c)> {
+        Let(in, match (IntSet.toList(noreturns), IntSet.toList(returns)) {
+                ([], []) => { vec![] },
+                ([entry], []) => { match IntMap.updateLookupWithKey((Lambda), entry, blocks) {
+                        (Just((s, term)), blocks') => { :(Structure(hashmap! {
+                                "structureEntries" => entries,
+                                "structureBody" => Simple(s, term)
+                                }), relooper((successors((s, term))), blocks')) },
+                        (Nothing, _) => { :(Structure(hashmap! {
+                                "structureEntries" => entries,
+                                "structureBody" => Simple(mempty, (Branch((GoTo(entry)))))
+                                }), vec![]) },
+                    } },
+            _ => if not((IntSet.null(absent))) { :(if(IntSet.null, present, then, vec![], else, Structure, hashmap! {
+                    "structureEntries" => entries,
+                    "structureBody" => Multiple((IntMap.fromSet((const(vec![])), absent)), (relooper(present, blocks)))
+                    }), vec![]) },
+                ([], _) => { :(Structure(hashmap! {
+                        "structureEntries" => entries,
+                        "structureBody" => Loop((relooper(entries, blocks')))
+                        }), relooper(followEntries, followBlocks)) },
+                _ => { :(Structure(hashmap! {
+                        "structureEntries" => entries,
+                        "structureBody" => Multiple(handlers, unhandled)
+                        }), relooper(followEntries, followBlocks)) },
+            })
+    }
+
+    fn relooperRoot(CFG(entry, blocks): CFG(k, s, c)) -> Vec<Structure(s, c)> {
+        relooper((IntSet.singleton(entry)))(IntMap.map((Lambda), blocks))
+    }
+
+    fn removeEmptyBlocks(CFG(start, blocks): CFG(k, f(s), c)) -> CFG(Unordered, f(s), c) {
+        CFG((rewrite(start)), blocks')
+    }
+
+    fn restrictKeys(m: IntMap.IntMap(a), s: IntSet.IntSet) -> IntMap.IntMap(a) {
+        IntMap.intersection(m, IntMap.fromSet((const(())), s))
+    }
+
+    fn simplifyStructure() -> Vec<Structure(s, c)> {
+        (foldr(go, vec![]) . map(descend))
+    }
+
+    fn structureCFG(mkBreak: fn(Maybe(Label)) -> s, mkContinue: fn(Maybe(Label)) -> s, mkLoop: fn(Label) -> fn(s) -> s, mkIf: fn(c) -> fn(s) -> fn(s) -> s, mkGoto: fn(Label) -> s, mkMatch: fn(Vec<(Label, s)>) -> fn(s) -> s, cfg: CFG(DepthFirst, s, c)) -> (Bool, s) {
+        (hasMultiple(root), foo(vec![], mempty, root))
+    }
+
+    fn successors((_, term): StructureBlock(s, c)) -> IntSet.IntSet {
+        IntSet.fromList(Dummy)
+    }
+
+}
 
 mod Language_Rust_Corrode_CrateMap {
     #[derive(Eq, Ord, Show)]
@@ -22,11 +958,7 @@ mod Language_Rust_Corrode_CrateMap {
 
     fn splitModuleMap(modName: String, crates: CratesMap) -> (ModuleMap, CratesMap) {
         fromMaybe((vec![], crates))({
-                let thisCrate = Map.lookup("".to_string(), crates);
-                let thisModule = Map.lookup(modName, thisCrate);
-                Let;
-                Let;
-                return((thisModule, crates'))
+
             })
     }
 
@@ -35,35 +967,35 @@ mod Language_Rust_Corrode_CrateMap {
 mod Language_Rust_Idiomatic {
     fn itemIdioms(__0: Rust.Item) -> Rust.Item {
         match (__0) {
-            Rust.Item(attrs, vis, Rust.Function(fattrs, name, formals, ret, b)) => Rust.Item(attrs, vis, (Rust.Function(fattrs, name, formals, ret, (tailBlock(b))))),
-            i => i,
+            Rust.Item(attrs, vis, Rust.Function(fattrs, name, formals, ret, b)) => { Rust.Item(attrs, vis, (Rust.Function(fattrs, name, formals, ret, (tailBlock(b))))) },
+            i => { i },
         }
     }
 
     fn tailBlock(__0: Rust.Block) -> Rust.Block {
         match (__0) {
-            Rust.Block(b, Just(Pair(Span([Ref(Ident("tailExpr"))]), Span([Ref(Ident("Just")), Ref(Ident("e"))])))) => Rust.Block(b, e),
-            Rust.Block(Pair(Span([Ref(Ident("unsnoc"))]), Span([Ref(Ident("Just")), Tuple([Span([Ref(Ident("b"))]), Span([Ref(Ident("Rust.Stmt")), Tuple([Pair(Span([Ref(Ident("tailExpr"))]), Span([Ref(Ident("Just")), Ref(Ident("e"))]))])])])])), Nothing) => Rust.Block(b, e),
-            b => b,
+            Rust.Block(b, Just((tailExpr -> Just(e)))) => { Rust.Block(b, e) },
+            Rust.Block((unsnoc -> Just((b, Rust.Stmt((tailExpr -> Just(e)))))), Nothing) => { Rust.Block(b, e) },
+            b => { b },
         }
     }
 
     fn tailExpr(__0: Rust.Expr) -> Maybe(Maybe(Rust.Expr)) {
         match (__0) {
-            Rust.Return(e) => Just(e),
-            Rust.BlockExpr(b) => Just((Just((Rust.BlockExpr((tailBlock(b))))))),
-            Rust.IfThenElse(c, t, f) => Just((Just((Rust.IfThenElse(c, (tailBlock(t)), (tailBlock(f))))))),
-            _ => Nothing,
+            Rust.Return(e) => { Just(e) },
+            Rust.BlockExpr(b) => { Just((Just((Rust.BlockExpr((tailBlock(b))))))) },
+            Rust.IfThenElse(c, t, f) => { Just((Just((Rust.IfThenElse(c, (tailBlock(t)), (tailBlock(f))))))) },
+            _ => { Nothing },
         }
     }
 
     fn unsnoc(__0: Vec<a>) -> Maybe((Vec<a>, a)) {
         match (__0) {
-            Vec<> => Nothing,
-            x(EmptyParen, xs) => match unsnoc(xs) {
-                    Just (a, b) => Just((:(x, a), b)),
-                    Nothing => Just((vec![], x)),
-                },
+            [] => { Nothing },
+            x:xs => { match unsnoc(xs) {
+                    Just, (a, b) => { Just((x:a, b)) },
+                    Nothing => { Just((vec![], x)) },
+                } },
         }
     }
 

--- a/out/language_c.rs
+++ b/out/language_c.rs
@@ -1,524 +1,26 @@
-mod Language_C_Analysis_AstAnalysis {
-    struct StmtCtx(FunCtx, VarDecl, LoopCtx, SwitchCtx);
-
-    #[derive(Eq, Show)]
-    struct ExprSide(LValue, RValue);
-
-    fn advanceDesigList(ds: Vec<CDesignator>, d: CDesignator) -> Vec<CDesignator> {
-        drop(1)(dropWhile(((not . matchDesignator(d))), ds))
-    }
-
-    fn analyseAST(CTranslUnit(decls, _file_node): CTranslUnit) -> m(GlobalDecls) {
-        {
-            let mapRecoverM_ = |f| {
-                mapM_(((handleTravError . f)))
-            };
-
-            mapRecoverM_(analyseExt, decls);
-            >>=(getDefTable, Lambda((not((inFileScope(dt)))))(error("Internal Error: Not in filescope after analysis".to_string())));
-            liftM(globalDefs, getDefTable)
-        }
-    }
-
-    fn analyseExt(__0: CExtDecl) -> m(EmptyParen) {
-        match (__0) {
-            CAsmExt(asm, _) => handleAsmBlock(asm),
-            CFDefExt(fundef) => analyseFunDef(fundef),
-            CDeclExt(decl) => analyseDecl(False, decl),
-        }
-    }
-
-    fn analyseFunDef(CFunDef(declspecs, declr, oldstyle_decls, stmt, node_info): CFunDef) -> m(EmptyParen) {
-        {
-            let improveFunDefType = |__0| {
-                match (__0) {
-                    FunctionType(FunTypeIncomplete(return_ty), attrs) => return(FunctionType((FunType(return_ty, vec![], False)), attrs)),
-                    ty => return(ty),
-                }
-            };
-
-            let var_decl_info = analyseVarDecl'(True, declspecs, declr, oldstyle_decls, Nothing);
-            Let;
-            when((isNoName(name)))(astError(node_info, "NoName in analyseFunDef".to_string()));
-            Let;
-            let ty' = improveFunDefType(ty);
-            let fun_storage = computeFunDefStorage(ident, storage_spec);
-            Let;
-            handleVarDecl(False, (Decl(var_decl, node_info)));
-            let stmt' = analyseFunctionBody(node_info, var_decl, stmt);
-            handleFunDef(ident, (FunDef(var_decl, stmt', node_info)))
-        }
-    }
-
-    fn analyseFunctionBody(__0: NodeInfo, __1: VarDecl, __2: CStat, __3: m(Stmt)) -> m(Stmt) {
-        match (__0, __1, __2, __3, __4) {
-            node_info decl s EmptyParen CCompound(localLabels, items, _) => {
-                enterFunctionScope;
-                mapM_(((withDefTable . defineLabel)), (++(localLabels, getLabels(s))));
-                defineParams(node_info, decl);
-                mapM_((tBlockItem(vec![FunCtx(decl)])), items);
-                leaveFunctionScope;
-                return(s)
-            },
-            _ _ s => astError((nodeInfo(s)), "Function body is no compound statement".to_string()),
-        }
-    }
-
-    fn analyseTypeDef(handle_sue_def: Bool, declspecs: Vec<CDeclSpec>, declr: CDeclr, node_info: NodeInfo) -> m(EmptyParen) {
-        {
-            let checkValidTypeDef = |__0, __1, __2| {
-                match (__0, __1, __2) {
-                    True _ _ => astError(node_info, "inline specifier for typeDef".to_string()),
-                    _ NoStorageSpec _ => return(()),
-                    _ bad_storage _ => astError(node_info)(++("storage specified for typeDef: ".to_string(), show(bad_storage))),
-                }
-            };
-
-            let (VarDeclInfo(name, is_inline, storage_spec, attrs, ty, declr_node)) = analyseVarDecl'(handle_sue_def, declspecs, declr, vec![], Nothing);
-            checkValidTypeDef(is_inline, storage_spec, attrs);
-            when((isNoName(name)))(astError(node_info, "NoName in analyseTypeDef".to_string()));
-            Let;
-            handleTypeDef((TypeDef(ident, ty, attrs, node_info)))
-        }
-    }
-
-    fn builtinType(__0: CBuiltin) -> m(Type) {
-        match (__0) {
-            CBuiltinVaArg(_, d, _) => analyseTypeDecl(d),
-            CBuiltinOffsetOf(_, _, _) => return(size_tType),
-            CBuiltinTypesCompatible(_, _, _) => return(boolType),
-        }
-    }
-
-    fn checkGuard(c: Vec<StmtCtx>, e: CExpr) -> m(EmptyParen) {
-        >>=(tExpr(c, RValue, e), checkScalar'((nodeInfo(e))))
-    }
-
-    fn checkInits(__0: Type, __1: Vec<CDesignator>, __2: CInitList) -> m(EmptyParen) {
-        match (__0, __1, __2) {
-            _ _ Vec<> => return(()),
-            t dds (ds, i)(EmptyParen, is) => {
-                let (dds', ds') = match (dds, ds) {
-                                (Vec<>, Vec<>) => typeError((nodeInfo(i)), "excess elements in initializer".to_string()),
-                                (dd'(EmptyParen, rest), Vec<>) => return((rest, vec![dd'])),
-                                (_, d(EmptyParen, _)) => return((advanceDesigList(dds, d), ds)),
-                            };
-                let t' = tDesignator(t, ds');
-                tInit(t', i);
-                checkInits(t, dds', is)
-            },
-        }
-    }
-
-    fn complexBaseType(ni: NodeInfo, c: Vec<StmtCtx>, side: ExprSide, e: CExpr) -> m(Type) {
-        {
-            let t = tExpr(c, side, e);
-            match canonicalType(t) {
-                        DirectType TyComplex(ft) quals attrs => return(DirectType((TyFloating(ft)), quals, attrs)),
-                        _ => typeError(ni)(++("expected complex type, got: ".to_string(), pType(t))),
-                    }
-        }
-    }
-
-    fn computeFunDefStorage(__0: Ident, __1: StorageSpec) -> m(Storage) {
-        match (__0, __1) {
-            _ StaticSpec(b) => return(FunLinkage(InternalLinkage)),
-            ident other_spec => {
-                let obj_opt = lookupObject(ident);
-                Let;
-                match other_spec {
-                            NoStorageSpec => return(maybe(defaultSpec, declStorage, obj_opt)),
-                            ExternSpec(False) => return(maybe(defaultSpec, declStorage, obj_opt)),
-                            bad_spec => throwTravError(badSpecifierError((nodeInfo(ident)))(++("unexpected function storage specifier (only static or extern is allowed)".to_string(), show(bad_spec)))),
-                        }
-            },
-        }
-    }
-
-    fn defaultMD() -> MachineDesc {
-        MachineDesc(hashmap! {
-            "iSize" => Lambda,
-            "fSize" => Lambda,
-            "builtinSize" => Lambda,
-            "ptrSize" => 4,
-            "voidSize" => 1,
-            "iAlign" => Lambda,
-            "fAlign" => Lambda,
-            "builtinAlign" => Lambda,
-            "ptrAlign" => 4,
-            "voidAlign" => 1
-            })
-    }
-
-    fn defineParams(ni: NodeInfo, decl: VarDecl) -> m(EmptyParen) {
-        match (getParams(declType(decl))) {
-                Nothing => astError(ni, "expecting complete function type in function definition".to_string()),
-                Just params => mapM_(handleParamDecl, params),
-            }
-    }
-
-    fn enclosingFunctionType(__0: Vec<StmtCtx>) -> Maybe(Type) {
-        match (__0) {
-            Vec<> => Nothing,
-            FunCtx(vd, EmptyParen, _) => Just(declType(vd)),
-            _(EmptyParen, cs) => enclosingFunctionType(cs),
-        }
-    }
-
-    fn extFunProto(VarDeclInfo(var_name, is_inline, storage_spec, attrs, ty, node_info): VarDeclInfo) -> m(EmptyParen) {
-        {
-            when((isNoName(var_name)))(astError(node_info, "NoName in extFunProto".to_string()));
-            let old_fun = lookupObject((identOfVarName(var_name)));
-            checkValidSpecs;
-            Let;
-            handleVarDecl(False, (Decl(decl, node_info)));
-            enterPrototypeScope;
-            maybe((return(())), (mapM_(handleParamDecl)), (getParams(ty)));
-            leavePrototypeScope
-        }
-    }
-
-    fn extVarDecl(VarDeclInfo(var_name, is_inline, storage_spec, attrs, typ, node_info): VarDeclInfo, init_opt: Maybe(Initializer)) -> m(EmptyParen) {
-        {
-            when((isNoName(var_name)))(astError(node_info, "NoName in extVarDecl".to_string()));
-            let (storage, is_def) = globalStorage(storage_spec);
-            Let;
-            if(is_def, then, handleObjectDef, False, ident)(ObjDef(vardecl, init_opt, node_info, else, handleVarDecl, False)(Decl(vardecl, node_info)))
-        }
-    }
-
-    fn getParams(__0: Type) -> Maybe(Vec<ParamDecl>) {
-        match (__0) {
-            FunctionType(FunType(_, params, _), _) => Just(params),
-            _ => Nothing,
-        }
-    }
-
-    fn hasTypeDef(declspecs: Vec<CDeclSpec>) -> Maybe(Vec<CDeclSpec>) {
-        match foldr(hasTypeDefSpec, (False, vec![]), declspecs) {
-                (True, specs') => Just(specs'),
-                (False, _) => Nothing,
-            }
-    }
-
-    fn inLoop(c: Vec<StmtCtx>) -> Bool {
-        any(isLoop, c)
-    }
-
-    fn inSwitch(c: Vec<StmtCtx>) -> Bool {
-        any(isSwitch, c)
-    }
-
-    fn localVarDecl(VarDeclInfo(var_name, is_inline, storage_spec, attrs, typ, node_info): VarDeclInfo, init_opt: Maybe(Initializer)) -> m(EmptyParen) {
-        {
-            when((isNoName(var_name)))(astError(node_info, "NoName in localVarDecl".to_string()));
-            let (storage, is_def) = localStorage(storage_spec);
-            Let;
-            if(is_def, then, handleObjectDef, True, ident, (ObjDef(vardecl, init_opt, node_info)), else, handleVarDecl, True, (Decl(vardecl, node_info)))
-        }
-    }
-
-    fn matchDesignator(__0: CDesignator, __1: CDesignator) -> Bool {
-        match (__0, __1) {
-            CMemberDesig(m1, _) CMemberDesig(m2, _) => ==(m1, m2),
-            _ _ => True,
-        }
-    }
-
-    fn tBlockItem(__0: Vec<StmtCtx>, __1: CBlockItem) -> m(Type) {
-        match (__0, __1) {
-            c CBlockStmt(s) => tStmt(c, s),
-            _ CBlockDecl(d) => >(analyseDecl(True, d), >((), return(voidType))),
-            _ CNestedFunDef(fd) => >(analyseFunDef(fd), >((), return(voidType))),
-        }
-    }
-
-    fn tDesignator(__0: Type, __1: Vec<CDesignator>) -> m(Type) {
-        match (__0, __1) {
-            ArrayType(bt, _, _, _) CArrDesig(e, ni, EmptyParen, ds) => {
-                >>=(tExpr(vec![], RValue, e), checkIntegral'(ni));
-                tDesignator(bt, ds)
-            },
-            ArrayType(bt, _, _, _) CRangeDesig(e1, e2, ni, EmptyParen, ds) => {
-                >>=(tExpr(vec![], RValue, e1), checkIntegral'(ni));
-                >>=(tExpr(vec![], RValue, e2), checkIntegral'(ni));
-                tDesignator(bt, ds)
-            },
-            ArrayType(_, _, _, _) d(EmptyParen, ds) => typeError((nodeInfo(d)), "member designator in array initializer".to_string()),
-            t EmptyParen DirectType(TyComp(_), _, _) CMemberDesig(m, ni, EmptyParen, ds) => {
-                let mt = fieldType(ni, m, t);
-                tDesignator((canonicalType(mt)), ds)
-            },
-            t EmptyParen DirectType(TyComp(_), _, _) d(EmptyParen, _) => typeError((nodeInfo(d)), "array designator in compound initializer".to_string()),
-            t Vec<> => return(t),
-        }
-    }
-
-    fn tExpr(c: Vec<StmtCtx>, side: ExprSide, e: CExpr) -> m(Type) {
-        match nameOfNode((nodeInfo(e))) {
-                Just n => {
-                    let dt = getDefTable;
-                    match lookupType(dt, n) {
-                                Just t => return(t),
-                                Nothing => {
-                                    let t = tExpr'(c, side, e);
-                                    withDefTable((Lambda))
-                                },
-                            }
-                },
-                Nothing => tExpr'(c, side, e),
-            }
-    }
-
-    fn tExpr'(__0: Vec<StmtCtx>, __1: ExprSide, __2: CExpr) -> m(Type) {
-        match (__0, __1, __2) {
-            c side CBinary(op, le, re, ni) => {
-                when((==(side, LValue)))(typeError(ni, "binary operator as lvalue".to_string()));
-                let lt = tExpr(c, RValue, le);
-                let rt = tExpr(c, RValue, re);
-                binopType'(ni, op, lt, rt)
-            },
-            c side CUnary(CAdrOp, e, ni) => {
-                when((==(side, LValue)))(typeError(ni, "address-of operator as lvalue".to_string()));
-                match e {
-                            CCompoundLit _ _ _ => liftM(simplePtr, tExpr(c, RValue, e)),
-                            CVar i _ => >>=(lookupObject(i), (typeErrorOnLeft(ni) . maybe((notFound(i)), varAddrType))),
-                            _ => liftM(simplePtr, tExpr(c, LValue, e)),
-                        }
-            },
-            c _ CUnary(CIndOp, e, ni) => >>=(tExpr(c, RValue, e), ((typeErrorOnLeft(ni) . derefType))),
-            c _ CUnary(CCompOp, e, ni) => {
-                let t = tExpr(c, RValue, e);
-                checkIntegral'(ni, t);
-                return(t)
-            },
-            c side CUnary(CNegOp, e, ni) => {
-                when((==(side, LValue)))(typeError(ni, "logical negation used as lvalue".to_string()));
-                >>=(tExpr(c, RValue, e), checkScalar'(ni));
-                return(boolType)
-            },
-            c side CUnary(op, e, _) => tExpr(c, (if(isEffectfulOp, op, then, LValue, else, side)), e),
-            c _ CIndex(b, i, ni) => {
-                let bt = tExpr(c, RValue, b);
-                let it = tExpr(c, RValue, i);
-                let addrTy = binopType'(ni, CAddOp, bt, it);
-                typeErrorOnLeft(ni)(derefType(addrTy))
-            },
-            c side CCond(e1, me2, e3, ni) => {
-                let t1 = tExpr(c, RValue, e1);
-                checkScalar'((nodeInfo(e1)), t1);
-                let t3 = tExpr(c, side, e3);
-                match me2 {
-                            Just e2 => {
-                                let t2 = tExpr(c, side, e2);
-                                conditionalType'(ni, t2, t3)
-                            },
-                            Nothing => conditionalType'(ni, t1, t3),
-                        }
-            },
-            c side CMember(e, m, deref, ni) => {
-                let t = tExpr(c, RValue, e);
-                let bt = if(deref, then, typeErrorOnLeft, ni, (derefType(t)), else, return, t);
-                fieldType(ni, m, bt)
-            },
-            c side CComma(es, _) => >>=(mapM((tExpr(c, side)), es), (return . last)),
-            c side CCast(d, e, ni) => {
-                let dt = analyseTypeDecl(d);
-                let et = tExpr(c, side, e);
-                typeErrorOnLeft(ni)(castCompatible(dt, et));
-                return(dt)
-            },
-            c side CSizeofExpr(e, ni) => {
-                when((==(side, LValue)))(typeError(ni, "sizeof as lvalue".to_string()));
-                tExpr(c, RValue, e);
-                return(size_tType)
-            },
-            c side CAlignofExpr(e, ni) => {
-                when((==(side, LValue)))(typeError(ni, "alignof as lvalue".to_string()));
-                tExpr(c, RValue, e);
-                return(size_tType)
-            },
-            c side CComplexReal(e, ni) => complexBaseType(ni, c, side, e),
-            c side CComplexImag(e, ni) => complexBaseType(ni, c, side, e),
-            _ side CLabAddrExpr(_, ni) => {
-                when((==(side, LValue)))(typeError(ni, "label address as lvalue".to_string()));
-                return(PtrType(voidType, noTypeQuals, vec![]))
-            },
-            _ side CCompoundLit(d, initList, ni) => {
-                when((==(side, LValue)))(typeError(ni, "compound literal as lvalue".to_string()));
-                let lt = analyseTypeDecl(d);
-                tInitList(ni, (canonicalType(lt)), initList);
-                return(lt)
-            },
-            _ RValue CAlignofType(_, _) => return(size_tType),
-            _ RValue CSizeofType(_, _) => return(size_tType),
-            _ LValue CAlignofType(_, ni) => typeError(ni, "alignoftype as lvalue".to_string()),
-            _ LValue CSizeofType(_, ni) => typeError(ni, "sizeoftype as lvalue".to_string()),
-            _ side CVar(i, ni) => >>=(lookupObject(i), maybe((typeErrorOnLeft(ni)(notFound(i))), ((return . declType)))),
-            _ _ CConst(c) => constType(c),
-            _ _ CBuiltinExpr(b) => builtinType(b),
-            c _ CCall(fe, args, ni) => {
-                Let;
-                let t = match fe {
-                                CVar i _ => >>=(lookupObject(i), maybe((fallback(i)), (const(tExpr(c, RValue, fe))))),
-                                _ => tExpr(c, RValue, fe),
-                            };
-                let atys = mapM((tExpr(c, RValue)), args);
-                match canonicalType(t) {
-                            PtrType FunctionType(FunType(rt, pdecls, varargs), _) _ _ => {
-                                Let;
-                                mapM_(checkArg)(zip3(ptys, atys, args));
-                                unless(varargs)(when((/=(length(atys), length(ptys))))(typeError(ni, "incorrect number of arguments".to_string())));
-                                return(canonicalType(rt))
-                            },
-                            PtrType FunctionType(FunTypeIncomplete(rt), _) _ _ => {
-                                return(canonicalType(rt))
-                            },
-                            _ => typeError(ni)(++("attempt to call non-function of type ".to_string(), pType(t))),
-                        }
-            },
-            c _ CAssign(op, le, re, ni) => {
-                let lt = tExpr(c, LValue, le);
-                let rt = tExpr(c, RValue, re);
-                when((constant(typeQuals(lt))))(typeError(ni)(++("assignment to lvalue with `constant\' qualifier: ".to_string(), ((render . pretty))(le))));
-                match (canonicalType(lt), re) {
-                        (lt', CConst(CIntConst(i, _))) => if &&(isPointerType(lt'), ==(getCInteger(i), 0)) { return(()) },
-                            (_, _) => assignCompatible'(ni, op, lt, rt),
-                        };
-                return(lt)
-            },
-            c _ CStatExpr(s, _) => {
-                enterBlockScope;
-                mapM_(((withDefTable . defineLabel)), (getLabels(s)));
-                let t = tStmt(c, s);
-                leaveBlockScope;
-                return(t)
-            },
-        }
-    }
-
-    fn tInit(__0: Type, __1: CInit, __2: m(Initializer)) -> m(Initializer) {
-        match (__0, __1, __2, __3) {
-            t i EmptyParen CInitExpr(e, ni) => {
-                let it = tExpr(vec![], RValue, e);
-                assignCompatible'(ni, CAssignOp, t, it);
-                return(i)
-            },
-            t i EmptyParen CInitList(initList, ni) => >(tInitList(ni, (canonicalType(t)), initList), >((), return(i))),
-        }
-    }
-
-    fn tInitList(__0: NodeInfo, __1: Type, __2: CInitList, __3: m(EmptyParen)) -> m(EmptyParen) {
-        match (__0, __1, __2, __3, __4) {
-            ni t EmptyParen ArrayType(DirectType(TyIntegral(TyChar), _, _), _, _, _) Vec<(Vec<>, CInitExpr(e, EmptyParen, CConst(CStrConst(_, _)), _))> => >(tExpr(vec![], RValue, e), >((), return(()))),
-            ni t EmptyParen ArrayType(_, _, _, _) initList => {
-                Let;
-                checkInits(t, default_ds, initList)
-            },
-            ni t EmptyParen DirectType(TyComp(ctr), _, _) initList => {
-                let td = lookupSUE(ni, (sueRef(ctr)));
-                let ms = tagMembers(ni, td);
-                Let;
-                checkInits(t, default_ds, initList)
-            },
-            ni PtrType(DirectType(TyVoid, _, _), _, _) _ => return(()),
-            _ t Vec<(Vec<>, i)> => >(tInit(t, i), >((), return(()))),
-            ni t _ => typeError(ni)(++("initializer list for type: ".to_string(), pType(t))),
-        }
-    }
-
-    fn tStmt(__0: Vec<StmtCtx>, __1: CStat) -> m(Type) {
-        match (__0, __1) {
-            c CLabel(_, s, _, _) => tStmt(c, s),
-            c CExpr(e, _) => maybe((return(voidType)), (tExpr(c, RValue)), e),
-            c CCompound(ls, body, _) => {
-                enterBlockScope;
-                mapM_(((withDefTable . defineLabel)), ls);
-                let t = foldM((const(tBlockItem(c))), voidType, body);
-                leaveBlockScope;
-                return(t)
-            },
-            c CIf(e, sthen, selse, _) => >(checkGuard(c, e), >((), >(tStmt(c, sthen), >((), >(maybe((return(())), (>(Lambda(c, s), >((), return(())))), selse), >((), return(voidType))))))),
-            c CSwitch(e, s, ni) => >>=(tExpr(c, RValue, e), >(checkIntegral'(ni), >((), tStmt((:(SwitchCtx, c)), s)))),
-            c CWhile(e, s, _, _) => >(checkGuard(c, e), >((), tStmt((:(LoopCtx, c)), s))),
-            _ CGoto(l, ni) => {
-                let dt = getDefTable;
-                match lookupLabel(l, dt) {
-                            Just _ => return(voidType),
-                            Nothing => typeError(ni)(++("undefined label in goto: ".to_string(), identToString(l))),
-                        }
-            },
-            c CCont(ni) => {
-                unless((inLoop(c)))(astError(ni, "continue statement outside of loop".to_string()));
-                return(voidType)
-            },
-            c CBreak(ni) => {
-                unless((||(inLoop(c), inSwitch(c))))(astError(ni, "break statement outside of loop or switch statement".to_string()));
-                return(voidType)
-            },
-            c CReturn(Just(e), ni) => {
-                let t = tExpr(c, RValue, e);
-                let rt = match enclosingFunctionType(c) {
-                                Just FunctionType(FunType(rt, _, _), _) => return(rt),
-                                Just FunctionType(FunTypeIncomplete(rt), _) => return(rt),
-                                Just ft => astError(ni)(++("bad function type: ".to_string(), pType(ft))),
-                                Nothing => astError(ni, "return statement outside function".to_string()),
-                            };
-                match (rt, t) {
-                            (DirectType(TyVoid, _, _), DirectType(TyVoid, _, _)) => return(()),
-                            _ => assignCompatible'(ni, CAssignOp, rt, t),
-                        };
-                return(voidType)
-            },
-            _ CReturn(Nothing, _) => return(voidType),
-            _ CAsm(_, _) => return(voidType),
-            c CCase(e, s, ni) => {
-                unless((inSwitch(c)))(astError(ni, "case statement outside of switch statement".to_string()));
-                >>=(tExpr(c, RValue, e), checkIntegral'(ni));
-                tStmt(c, s)
-            },
-            c CCases(e1, e2, s, ni) => {
-                unless((inSwitch(c)))(astError(ni, "case statement outside of switch statement".to_string()));
-                >>=(tExpr(c, RValue, e1), checkIntegral'(ni));
-                >>=(tExpr(c, RValue, e2), checkIntegral'(ni));
-                tStmt(c, s)
-            },
-            c CDefault(s, ni) => {
-                unless((inSwitch(c)))(astError(ni, "default statement outside of switch statement".to_string()));
-                tStmt(c, s)
-            },
-            c CFor(i, g, inc, s, _) => {
-                enterBlockScope;
-                either((maybe((return(())), checkExpr)), (analyseDecl(True)), i);
-                maybe((return(())), (checkGuard(c)), g);
-                maybe((return(())), checkExpr, inc);
-                tStmt((:(LoopCtx, c)), s);
-                leaveBlockScope;
-                return(voidType)
-            },
-            c CGotoPtr(e, ni) => {
-                let t = tExpr(c, RValue, e);
-                match t {
-                            PtrType(_, _, _) => return(voidType),
-                            _ => typeError(ni, "can\'t goto non-pointer".to_string()),
-                        }
-            },
-        }
-    }
-
-}
-
-mod Language_C_Analysis_Builtins {
-    fn builtins() -> DefTable {
-        foldr(doIdent, (foldr(doTypeDef, emptyDefTable, typedefs)), idents)
-    }
-
-}
-
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/ConstEval.hs"
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/AstAnalysis.hs"
+Error: Unrecognized token `->`:
+117 |     | null declrs =
+118 |         case typedef_spec of{ Just _  -> astError node "YmFkIHR5cGVkZW
+119 |                               Nothing -> analyseTypeDecl decl >> retur
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/Builtins.hs"
+Error: Unrecognized token `=`:
+ 10 | ;builtins = foldr doIdent (foldr doTypeDef emptyDefTable typedefs) ide
+ 11 |   where{ doTypeDef d = snd . defineTypeDef (identOfTypeDef d) d
+ 12 |          doIdent   d = snd . defineGlobalIdent (declIdent d) d
+~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/ConstEval.hs"
+Error: Unrecognized token `->`:
+ 21 | ;data MachineDesc =
+ 22 |   MachineDesc
+ 23 |   { iSize        :: IntType -> Integer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Analysis_Debug {
-    fn globalDeclStats(file_filter: Pair(Span([Ref(Ident("FilePath"))]), Span([Ref(Ident("Bool"))])), gmap: GlobalDecls) -> Vec<(String, isize)> {
+    fn globalDeclStats(file_filter: fn(FilePath) -> Bool, gmap: GlobalDecls) -> Vec<(String, isize)> {
         vec![("Enumeration Constants".to_string(), Map.size(enumerators)), ("Total Object/Function Declarations".to_string(), Map.size(all_decls)), ("Object definitions".to_string(), Map.size(objDefs)), ("Function Definitions".to_string(), Map.size(funDefs)), ("Tag definitions".to_string(), Map.size(tagDefs)), ("TypeDefs".to_string(), Map.size(typeDefs))]
     }
 
@@ -530,8 +32,8 @@ mod Language_C_Analysis_Debug {
         prettyAssocsWith(label, pretty, pretty)
     }
 
-    fn prettyAssocsWith(label: String, prettyKey: Pair(Span([Ref(Ident("k"))]), Span([Ref(Ident("Doc"))])), prettyVal: Pair(Span([Ref(Ident("v"))]), Span([Ref(Ident("Doc"))])), theMap: Vec<(k, v)>) -> Doc {
-        text(label)(()((nest(8))((vcat(map(prettyEntry, theMap))))))
+    fn prettyAssocsWith(label: String, prettyKey: fn(k) -> Doc, prettyVal: fn(v) -> Doc, theMap: Vec<(k, v)>) -> Doc {
+        $$(text(label), (nest(8))((vcat(map(prettyEntry, theMap)))))
     }
 
     fn terminateSemi() -> Doc {
@@ -539,243 +41,450 @@ mod Language_C_Analysis_Debug {
     }
 
     fn terminateSemi_() -> Doc {
-        (hsep . map((<((), Operator(">")(semi)))))
+        (hsep . map((Operator("<>")(semi))))
     }
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/DeclAnalysis.hs"
+mod Language_C_Analysis_DeclAnalysis {
+    #[derive(Eq, Ord, Show, Read)]
+    struct StorageSpec(NoStorageSpec, AutoSpec, RegSpec, ThreadSpec, StaticSpec, Bool, ExternSpec, Bool);
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/DefTable.hs"
+    struct VarDeclInfo(VarDeclInfo, VarName, Bool, StorageSpec, Attributes, Type, NodeInfo);
 
-mod Language_C_Analysis_Export {
-    fn exportArraySize(__0: ArraySize) -> CArrSize {
-        match (__0) {
-            ArraySize(static, e) => CArrSize(static, e),
-            UnknownArraySize(complete) => CNoArrSize(complete),
+    #[derive(Eq, Ord)]
+    struct NumBaseType(NoBaseType, BaseChar, BaseInt, BaseFloat, BaseDouble);
+
+    #[derive(Eq, Ord)]
+    struct SignSpec(NoSignSpec, Signed, Unsigned);
+
+    #[derive(Eq, Ord)]
+    struct SizeMod(NoSizeMod, ShortMod, LongMod, LongLongMod);
+
+    struct NumTypeSpec(NumTypeSpec, { /* struct def */ });
+
+    struct TypeSpecAnalysis(TSNone, TSVoid, TSBool, TSNum, NumTypeSpec, TSTypeDef, TypeDefRef, TSType, Type, TSNonBasic, CTypeSpec);
+
+    fn analyseVarDecl(handle_sue_def: Bool, storage_specs: Vec<CStorageSpec>, decl_attrs: Vec<CAttr>, typequals: Vec<CTypeQual>, canonTySpecs: TypeSpecAnalysis, inline: Bool, CDeclr(name_opt, derived_declrs, asmname_opt, declr_attrs, node): CDeclr, oldstyle_params: Vec<CDecl>, init_opt: Maybe(CInit)) -> m(VarDeclInfo) {
+        {
+
         }
     }
 
-    fn exportAttrs() -> Vec<CAttr> {
-        map(exportAttr)
+    fn analyseVarDecl'(handle_sue_def: Bool, declspecs: Vec<CDeclSpec>, declr: CDeclr, oldstyle: Vec<CDecl>, init_opt: Maybe(CInit)) -> m(VarDeclInfo) {
+        {
+
+        }
     }
 
-    fn exportCompType(CompType(sue_ref, comp_tag, members, attrs, node_info): CompType) -> Vec<CTypeSpec> {
-        vec![CSUType(comp, ni)]
+    fn canonicalStorageSpec(storagespecs: Vec<CStorageSpec>) -> m(StorageSpec) {
+        liftM(elideAuto)(foldrM(updStorage, NoStorageSpec, storagespecs))
     }
 
-    fn exportCompTypeDecl(ty: CompTypeRef) -> Vec<CTypeSpec> {
-        vec![CSUType((exportComp(ty)), ni)]
+    fn canonicalTypeSpec() -> m(TypeSpecAnalysis) {
+        foldrM(go, TSNone)
     }
 
-    fn exportCompTypeRef(CompType(sue_ref, com_tag, _, _, node_info): CompType) -> Vec<CTypeSpec> {
-        exportCompTypeDecl((CompTypeRef(sue_ref, com_tag, node_info)))
+    fn computeParamStorage(__0: NodeInfo, __1: StorageSpec) -> Either(BadSpecifierError, Storage) {
+        match (__0, __1) {
+            _, NoStorageSpec => { Right((Auto(False))) },
+            _, RegSpec => { Right((Auto(True))) },
+            node, spec => { (Left . badSpecifierError(node)(++("Bad storage specified for parameter: ".to_string(), show(spec)))) },
+        }
     }
 
-    fn exportComplexType(ty: FloatType) -> Vec<CTypeSpec> {
-        :((CComplexType(ni)), exportFloatType(ty))
+    fn emptyDeclr(node: NodeInfo) -> CDeclr {
+        CDeclr(Nothing, vec![], Nothing, vec![], node)
     }
 
-    fn exportDeclAttrs(DeclAttrs(inline, storage, attrs): DeclAttrs) -> Vec<CDeclSpec> {
-        ++((if(inline, then, vec![CTypeQual((CInlineQual(ni)))], else, vec![])), ++(map((CStorageSpec), (exportStorage(storage))), map(((CTypeQual . CAttrQual)), (exportAttrs(attrs)))))
+    fn emptyNumTypeSpec() -> NumTypeSpec {
+        NumTypeSpec(hashmap! {
+            "base" => NoBaseType,
+            "signSpec" => NoSignSpec,
+            "sizeMod" => NoSizeMod,
+            "isComplex" => False
+            })
     }
 
-    fn exportDeclr(other_specs: Vec<CDeclSpec>, ty: Type, attrs: Attributes, name: VarName) -> (Vec<CDeclSpec>, CDeclr) {
-        (++(other_specs, specs), CDeclr(ident, derived, asmname, (exportAttrs(attrs)), ni))
+    fn getOnlyDeclr(__0: CDecl) -> m(CDeclr) {
+        match (__0) {
+            CDecl(_, [(Just(declr), _, _)], _) => { return(declr) },
+            CDecl(_, _, node) => { internalErr("getOnlyDeclr: declaration doesn\'t have a unique declarator".to_string()) },
+        }
     }
 
-    fn exportEnumType(EnumType(sue_ref, enumerators, attrs, node_info): EnumType) -> Vec<CTypeSpec> {
-        vec![CEnumType(enum, ni)]
+    fn hasThreadLocalSpec(__0: StorageSpec) -> Bool {
+        match (__0) {
+            ThreadSpec => { True },
+            StaticSpec(b) => { b },
+            ExternSpec(b) => { b },
+            _ => { False },
+        }
     }
 
-    fn exportEnumTypeDecl(ty: EnumTypeRef) -> Vec<CTypeSpec> {
-        vec![CEnumType((exportEnum(ty)), ni)]
+    fn isTypeDef(declspecs: Vec<CDeclSpec>) -> Bool {
+        not(null(Dummy))
     }
 
-    fn exportEnumTypeRef(EnumType(sue_ref, _, _, node_info): EnumType) -> Vec<CTypeSpec> {
-        exportEnumTypeDecl((EnumTypeRef(sue_ref, node_info)))
+    fn mergeOldStyle(__0: NodeInfo, __1: Vec<CDecl>, __2: Vec<CDerivedDeclr>) -> m(Vec<CDerivedDeclr>) {
+        match (__0, __1, __2) {
+            _node, [], declrs => { return(declrs) },
+            node, oldstyle_params, CFunDeclr(params, attrs, fdnode, :, dds) => { match params {
+                    Left, list => { {
+
+                    } },
+                    Right, _newstyle => { astError(node, "oldstyle parameter list, but newstyle function declaration".to_string()) },
+                } },
+            node, _, _ => { astError(node, "oldstyle parameter list, but not function type".to_string()) },
+        }
     }
 
-    fn exportFloatType(ty: FloatType) -> Vec<CTypeSpec> {
-        match ty {
-                TyFloat => vec![CFloatType(ni)],
-                TyDouble => vec![CDoubleType(ni)],
-                TyLDouble => vec![CLongType(ni), CDoubleType(ni)],
+    fn mergeTypeAttributes(node_info: NodeInfo, quals: TypeQuals, attrs: Vec<Attr>, typ: Type) -> m(Type) {
+        match typ {
+                DirectType, ty_name, quals', attrs' => { merge(quals', attrs')(mkDirect(ty_name)) },
+                PtrType, ty, quals', attrs' => { merge(quals', attrs')(PtrType(ty)) },
+                ArrayType, ty, array_sz, quals', attrs' => { merge(quals', attrs')(ArrayType(ty, array_sz)) },
+                FunctionType, FunType(return_ty, params, inline), attrs' => { return(FunctionType((FunType(return_ty, params, inline)), (++(attrs', attrs)))) },
+                TypeDefType, tdr, quals', attrs' => { merge(quals', attrs')(TypeDefType(tdr)) },
             }
     }
 
-    fn exportIntType(ty: IntType) -> Vec<CTypeSpec> {
-        match ty {
-                TyBool => vec![CBoolType(ni)],
-                TyChar => vec![CCharType(ni)],
-                TySChar => vec![CSignedType(ni), CCharType(ni)],
-                TyUChar => vec![CUnsigType(ni), CCharType(ni)],
-                TyShort => vec![CShortType(ni)],
-                TyUShort => vec![CUnsigType(ni), CShortType(ni)],
-                TyInt => vec![CIntType(ni)],
-                TyUInt => vec![CUnsigType(ni), CIntType(ni)],
-                TyLong => vec![CLongType(ni)],
-                TyULong => vec![CUnsigType(ni), CLongType(ni)],
-                TyLLong => vec![CLongType(ni), CLongType(ni)],
-                TyULLong => vec![CUnsigType(ni), CLongType(ni), CLongType(ni)],
+    fn mkVarName(__0: NodeInfo, __1: Maybe(Ident), __2: Maybe(AsmName)) -> m(VarName) {
+        match (__0, __1, __2) {
+            node, Nothing, _ => { return(NoName) },
+            node, Just(n), asm => { return(VarName(n, asm)) },
+        }
+    }
+
+    fn nameOfDecl(d: CDecl) -> m(Ident) {
+        >>=(getOnlyDeclr(d), Lambda)
+    }
+
+    fn splitCDecl(decl: CDecl, <todo>: m(Vec<CDecl>)) -> m(Vec<CDecl>) {
+        match declrs {
+                [] => { internalErr("splitCDecl applied to empty declaration".to_string()) },
+                [declr] => { return(vec![decl]) },
+                d1:ds => { Let },
             }
     }
 
-    fn exportMemberDecl(__0: MemberDecl) -> CDecl {
+    fn tArraySize(__0: CArrSize) -> m(ArraySize) {
         match (__0) {
-            AnonBitField(ty, expr, node_info) => CDecl((map(CTypeSpec)(exportTypeSpec(fromDirectType(ty)))), vec![(Nothing, Nothing, Just(expr))], node_info),
-            MemberDecl(vardecl, bitfieldsz, node_info) => Let(in, CDecl, specs, vec![(Just(declarator), Nothing, bitfieldsz)], node_info),
+            CNoArrSize(False) => { return((UnknownArraySize(False))) },
+            CNoArrSize(True) => { return((UnknownArraySize(True))) },
+            CArrSize(static, szexpr) => { liftM((ArraySize(static)), (return(szexpr))) },
         }
     }
 
-    fn exportParamDecl(paramdecl: ParamDecl) -> CDecl {
-        Let(in, CDecl, specs, vec![(Just(declr), Nothing, Nothing)], (nodeInfo(paramdecl)))
+    fn tAttr(CAttr(name, cexpr, node): CAttr) -> m(Attr) {
+        return(Attr(name, cexpr, node))
     }
 
-    fn exportSUERef() -> Maybe(Ident) {
-        (Just . (internalIdent . show))
+    fn tCompType(tag: SUERef, sue_ref: CompTyKind, member_decls: Vec<CDecl>, attrs: Attributes, node: NodeInfo) -> m(CompType) {
+        ap(return((CompType(tag, sue_ref))), ap((concatMapM(tMemberDecls, member_decls)), ap((return(attrs)), (return(node)))))
     }
 
-    fn exportStorage(__0: Storage) -> Vec<CStorageSpec> {
-        match (__0) {
-            NoStorage => vec![],
-            Auto(reg) => if(reg, then, vec![CRegister(ni)], else, vec![]),
-            Static(InternalLinkage, thread_local) => threadLocal(thread_local, vec![CStatic(ni)]),
-            Static(ExternalLinkage, thread_local) => threadLocal(thread_local, vec![CExtern(ni)]),
-            Static(NoLinkage, _) => error("impossible storage: static without linkage".to_string()),
-            FunLinkage(InternalLinkage) => vec![CStatic(ni)],
-            FunLinkage(ExternalLinkage) => vec![],
-            FunLinkage(NoLinkage) => error("impossible storage: function without linkage".to_string()),
+    fn tCompTypeDecl(handle_def: Bool, CStruct(tag, ident_opt, member_decls_opt, attrs, node_info): CStructUnion) -> m(CompTypeRef) {
+        {
+
         }
     }
 
-    fn exportType(ty: Type) -> (Vec<CDeclSpec>, Vec<CDerivedDeclr>) {
-        exportTy(vec![], ty)
+    fn tDirectType(handle_sue_def: Bool, node: NodeInfo, ty_quals: Vec<CTypeQual>, canonTySpec: TypeSpecAnalysis) -> m(Type) {
+        {
+
+        }
     }
 
-    fn exportTypeDecl(ty: Type) -> CDecl {
-        CDecl(declspecs, declrs, ni)
+    fn tEnumType(sue_ref: SUERef, enumerators: Vec<(Ident, Maybe(CExpr))>, attrs: Attributes, node: NodeInfo) -> m(EnumType) {
+        {
+
+        }
     }
 
-    fn exportTypeDef(TypeDef(ident, ty, attrs, node_info): TypeDef) -> CDecl {
-        CDecl((:(CStorageSpec((CTypedef(ni))), declspecs)), vec![declr], node_info)
+    fn tMemberDecls(__0: CDecl) -> m(Vec<MemberDecl>) {
+        match (__0) {
+            CDecl(declspecs, [], node) => { {
+
+            } },
+            CDecl(declspecs, declrs, node) => { mapM((uncurry(tMemberDecl)), (zip((True:repeat(False)), declrs))) },
+        }
     }
 
-    fn exportTypeQuals(quals: TypeQuals) -> Vec<CTypeQual> {
-        mapMaybe(select, vec![(constant, CConstQual(ni)), (volatile, CVolatQual(ni)), (restrict, CRestrQual(ni))])
-    }
-
-    fn exportTypeQualsAttrs(tyqs: TypeQuals, attrs: Attributes) -> Vec<CTypeQual> {
-        (++(exportTypeQuals(tyqs), map(CAttrQual, (exportAttrs(attrs)))))
-    }
-
-    fn exportTypeSpec(tyname: TypeName) -> Vec<CTypeSpec> {
-        match tyname {
-                TyVoid => vec![CVoidType(ni)],
-                TyIntegral ity => exportIntType(ity),
-                TyFloating fty => exportFloatType(fty),
-                TyComplex fty => exportComplexType(fty),
-                TyComp comp => exportCompTypeDecl(comp),
-                TyEnum enum => exportEnumTypeDecl(enum),
-                TyBuiltin TyVaList => vec![CTypeDef((internalIdent("va_list".to_string())), ni)],
-                TyBuiltin TyAny => vec![CTypeDef((internalIdent("__ty_any".to_string())), ni)],
+    fn tNumType(NumTypeSpec(basetype, sgn, sz, iscomplex): NumTypeSpec) -> m(Either((FloatType, Bool), IntType)) {
+        match (basetype, sgn, sz) {
+            (BaseChar, _, NoSizeMod) => if let Signed = sgn { intType(TySChar) }
+let Unsigned = sgn { intType(TyUChar) }
+otherwise { intType(TyChar) },
+            (intbase, _, NoSizeMod) => if optBase(BaseInt, intbase) { intType(match sgn {
+                        Unsigned => { TyUInt },
+                        _ => { TyInt },
+                    }) },
+            (intbase, signed, sizemod) => if optBase(BaseInt, intbase) && optSign(Signed, signed) { intType(match sizemod {
+                        ShortMod => { TyShort },
+                        LongMod => { TyLong },
+                        LongLongMod => { TyLLong },
+                        _ => { internalErr("numTypeMapping: unexpected pattern matching error".to_string()) },
+                    }) },
+            (intbase, Unsigned, sizemod) => if optBase(BaseInt, intbase) { intType(match sizemod {
+                        ShortMod => { TyUShort },
+                        LongMod => { TyULong },
+                        LongLongMod => { TyULLong },
+                        _ => { internalErr("numTypeMapping: unexpected pattern matching error".to_string()) },
+                    }) },
+                (BaseFloat, NoSignSpec, NoSizeMod) => { floatType(TyFloat) },
+                (BaseDouble, NoSignSpec, NoSizeMod) => { floatType(TyDouble) },
+                (BaseDouble, NoSignSpec, LongMod) => { floatType(TyLDouble) },
+                (_, _, _) => { error("Bad AST analysis".to_string()) },
             }
     }
 
-    fn exportVarDecl(VarDecl(name, attrs, ty): VarDecl) -> (Vec<CDeclSpec>, CDeclr) {
-        exportDeclr((exportDeclAttrs(attrs)), ty, vec![], name)
-    }
+    fn tParamDecl(CDecl(declspecs, declrs, node): CDecl) -> m(ParamDecl) {
+        {
 
-    fn fromDirectType(__0: Type) -> TypeName {
-        match (__0) {
-            DirectType(ty, _, _) => ty,
-            TypeDefType(TypeDefRef(_, ref, _), _, _) => maybe((error("undefined typeDef".to_string())), fromDirectType, ref),
-            _ => error("fromDirectType".to_string()),
         }
     }
 
-    fn ni() -> NodeInfo {
-        undefNode
+    fn tTag(__0: CStructTag) -> CompTyKind {
+        match (__0) {
+            CStructTag => { StructTag },
+            CUnionTag => { UnionTag },
+        }
     }
 
-    fn threadLocal(__0: Bool) -> Vec<CStorageSpec> {
+    fn tType(handle_sue_def: Bool, top_node: NodeInfo, typequals: Vec<CTypeQual>, canonTySpecs: TypeSpecAnalysis, derived_declrs: Vec<CDerivedDeclr>, oldstyle_params: Vec<CDecl>) -> m(Type) {
+        >>=(mergeOldStyle(top_node, oldstyle_params, derived_declrs), buildType)
+    }
+
+    fn tTypeQuals() -> m((TypeQuals, Attributes)) {
+        foldrM(go, (noTypeQuals, vec![]))
+    }
+
+    fn typeDefRef(t_node: NodeInfo, name: Ident) -> m(TypeDefRef) {
+        >>=(lookupTypeDef(name), Lambda((TypeDefRef(name, (Just(ty)), t_node))))
+    }
+
+}
+
+mod Language_C_Analysis_DefTable {
+    struct TagFwdDecl(CompDecl, CompTypeRef, EnumDecl, EnumTypeRef);
+
+    struct DefTable(DefTable, { /* struct def */ });
+
+    #[derive(Clone, Debug)]
+    struct DeclarationStatus(NewDecl, Redeclared, t, KeepDef, t, Shadowed, t, KindMismatch, t);
+
+    #[derive(Eq, Ord)]
+    struct TagEntryKind(CompKind, CompTyKind, EnumKind);
+
+    fn compatIdentEntry(__0: IdentEntry) -> Bool {
         match (__0) {
-            False => id,
-            True => ((CThread(ni))(Operator(":"))),
+            Left(_tydef) => { either((const(True)), (const(False))) },
+            Right(def) => { either((const(False)))(Lambda) },
+        }
+    }
+
+    fn compatTagEntry(te1: TagEntry, te2: TagEntry) -> Bool {
+        ==(tagKind(te1), tagKind(te2))
+    }
+
+    fn declStatusDescr(__0: DeclarationStatus(t)) -> String {
+        match (__0) {
+            NewDecl => { "new".to_string() },
+            Redeclared(_) => { "redeclared".to_string() },
+            KeepDef(_) => { "keep old".to_string() },
+            Shadowed(_) => { "shadowed".to_string() },
+            KindMismatch(_) => { "kind mismatch".to_string() },
+        }
+    }
+
+    fn declareTag(sueref: SUERef, decl: TagFwdDecl, deftbl: DefTable) -> (DeclarationStatus(TagEntry), DefTable) {
+        match lookupTag(sueref, deftbl) {
+                Nothing => { (NewDecl, deftbl(hashmap! {
+                        "tagDecls" => fst(defLocal((tagDecls(deftbl)), sueref, (Left(decl))))
+                        })) },
+            Just, old_def => if ==(tagKind(old_def), tagKind((Left(decl)))) { (KeepDef(old_def), deftbl) }
+otherwise { (KindMismatch(old_def), deftbl) },
+            }
+    }
+
+    fn defRedeclStatus(sameKind: fn(t) -> fn(t) -> Bool, def: t, oldDecl: Maybe(t)) -> DeclarationStatus(t) {
+        match oldDecl {
+            Just, def' => if sameKind(def, def') { Redeclared(def') }
+otherwise { KindMismatch(def') },
+                Nothing => { NewDecl },
+            }
+    }
+
+    fn defRedeclStatusLocal(sameKind: fn(t) -> fn(t) -> Bool, ident: k, def: t, oldDecl: Maybe(t), nsm: NameSpaceMap(k, t)) -> DeclarationStatus(t) {
+        match defRedeclStatus(sameKind, def, oldDecl) {
+                NewDecl => { match lookupName(nsm, ident) {
+                        Just, shadowed => { Shadowed(shadowed) },
+                        Nothing => { NewDecl },
+                    } },
+                redecl => { redecl },
+            }
+    }
+
+    fn defineGlobalIdent(ident: Ident, def: IdentDecl, deftbl: DefTable) -> (DeclarationStatus(IdentEntry), DefTable) {
+        (defRedeclStatus(compatIdentEntry, (Right(def)), oldDecl), deftbl(hashmap! {
+                "identDecls" => decls'
+                }))
+    }
+
+    fn defineLabel(ident: Ident, deftbl: DefTable) -> (DeclarationStatus(Ident), DefTable) {
+        Let
+    }
+
+    fn defineScopedIdent() -> (DeclarationStatus(IdentEntry), DefTable) {
+        defineScopedIdentWhen((const(True)))
+    }
+
+    fn defineScopedIdentWhen(override_def: fn(IdentDecl) -> Bool, ident: Ident, def: IdentDecl, deftbl: DefTable) -> (DeclarationStatus(IdentEntry), DefTable) {
+        (redecl_status, deftbl(hashmap! {
+                "identDecls" => decls'
+                }))
+    }
+
+    fn defineTag(sueref: SUERef, def: TagDef, deftbl: DefTable) -> (DeclarationStatus(TagEntry), DefTable) {
+        (redeclStatus, deftbl(hashmap! {
+                "tagDecls" => decls'
+                }))
+    }
+
+    fn defineTypeDef(ident: Ident, tydef: TypeDef, deftbl: DefTable) -> (DeclarationStatus(IdentEntry), DefTable) {
+        (defRedeclStatus(compatIdentEntry, (Left(tydef)), oldDecl), deftbl(hashmap! {
+                "identDecls" => decls'
+                }))
+    }
+
+    fn emptyDefTable() -> DefTable {
+        DefTable(nameSpaceMap, nameSpaceMap, nameSpaceMap, nameSpaceMap, IntMap.empty, IntMap.empty)
+    }
+
+    fn enterBlockScope(deftbl: DefTable) -> DefTable {
+        enterLocalScope(deftbl(hashmap! {
+                "labelDefs" => enterNewScope((labelDefs(deftbl)))
+                }))
+    }
+
+    fn enterFunctionScope(deftbl: DefTable) -> DefTable {
+        enterLocalScope(deftbl(hashmap! {
+                "labelDefs" => enterNewScope((labelDefs(deftbl)))
+                }))
+    }
+
+    fn enterLocalScope(deftbl: DefTable) -> DefTable {
+        deftbl(hashmap! {
+            "identDecls" => enterNewScope((identDecls(deftbl))),
+            "tagDecls" => enterNewScope((tagDecls(deftbl)))
+            })
+    }
+
+    fn enterMemberDecl(deftbl: DefTable) -> DefTable {
+        deftbl(hashmap! {
+            "memberDecls" => enterNewScope((memberDecls(deftbl)))
+            })
+    }
+
+    fn globalDefs(deftbl: DefTable) -> GlobalDecls {
+        Map.foldWithKey(insertDecl, (GlobalDecls(e, gtags, e)), (globalNames(identDecls(deftbl))))
+    }
+
+    fn identOfTyDecl() -> Ident {
+        either(identOfTypeDef, declIdent)
+    }
+
+    fn inFileScope(dt: DefTable) -> Bool {
+        not((||(hasLocalNames((identDecls(dt))), hasLocalNames((labelDefs(dt))))))
+    }
+
+    fn insertType(dt: DefTable, n: Name, t: Type) -> DefTable {
+        dt(hashmap! {
+            "typeTable" => IntMap.insert((nameId(n)), t, (typeTable(dt)))
+            })
+    }
+
+    fn leaveBlockScope(deftbl: DefTable) -> DefTable {
+        leaveLocalScope(deftbl(hashmap! {
+                "labelDefs" => leaveScope_((labelDefs(deftbl)))
+                }))
+    }
+
+    fn leaveFunctionScope(deftbl: DefTable) -> DefTable {
+        leaveLocalScope(deftbl(hashmap! {
+                "labelDefs" => leaveScope_((labelDefs(deftbl)))
+                }))
+    }
+
+    fn leaveLocalScope(deftbl: DefTable) -> DefTable {
+        deftbl(hashmap! {
+            "identDecls" => leaveScope_((identDecls(deftbl))),
+            "tagDecls" => leaveScope_((tagDecls(deftbl)))
+            })
+    }
+
+    fn leaveMemberDecl(deftbl: DefTable) -> (Vec<MemberDecl>, DefTable) {
+        Let
+    }
+
+    fn leaveScope_() -> NameSpaceMap(k, a) {
+        (fst . leaveScope)
+    }
+
+    fn lookupIdent(ident: Ident, deftbl: DefTable) -> Maybe(IdentEntry) {
+        lookupName((identDecls(deftbl)), ident)
+    }
+
+    fn lookupIdentInner(ident: Ident, deftbl: DefTable) -> Maybe(IdentEntry) {
+        lookupInnermostScope((identDecls(deftbl)), ident)
+    }
+
+    fn lookupLabel(ident: Ident, deftbl: DefTable) -> Maybe(Ident) {
+        lookupName((labelDefs(deftbl)), ident)
+    }
+
+    fn lookupTag(sue_ref: SUERef, deftbl: DefTable) -> Maybe(TagEntry) {
+        lookupName((tagDecls(deftbl)), sue_ref)
+    }
+
+    fn lookupTagInner(sue_ref: SUERef, deftbl: DefTable) -> Maybe(TagEntry) {
+        lookupInnermostScope((tagDecls(deftbl)), sue_ref)
+    }
+
+    fn lookupType(dt: DefTable, n: Name) -> Maybe(Type) {
+        IntMap.lookup((nameId(n)), (typeTable(dt)))
+    }
+
+    fn mergeDefTable(DefTable(i1, t1, l1, m1, r1, tt1): DefTable, DefTable(i2, t2, l2, m2, r2, tt2): DefTable) -> DefTable {
+        DefTable((mergeNameSpace(i1, i2)), (mergeNameSpace(t1, t2)), (mergeNameSpace(l1, l2)), (mergeNameSpace(m1, m2)), (union(r1, r2)), (union(tt1, tt2)))
+    }
+
+    fn tagKind(__0: TagEntry) -> TagEntryKind {
+        match (__0) {
+            Left(CompDecl(cd)) => { CompKind((compTag(cd))) },
+            Left(EnumDecl(_)) => { EnumKind },
+            Right(CompDef(cd)) => { CompKind((compTag(cd))) },
+            Right(EnumDef(_)) => { EnumKind },
         }
     }
 
 }
 
-mod Language_C_Analysis_NameSpaceMap {
-    struct NameSpaceMap(NsMap, Map(k, v), Vec<Vec<(k, v)>>);
-
-    fn defGlobal(NsMap(gs, lss): NameSpaceMap(k, a), ident: k, def: a) -> (NameSpaceMap(k, a), Maybe(a)) {
-        (NsMap((Map.insert(ident, def, gs)), lss), Map.lookup(ident, gs))
-    }
-
-    fn defLocal(__0: NameSpaceMap(k, a), __1: k, __2: a, __3: (NameSpaceMap(k, a), Maybe(a))) -> (NameSpaceMap(k, a), Maybe(a)) {
-        match (__0, __1, __2, __3, __4) {
-            ns EmptyParen NsMap(_, Vec<>) ident def => defGlobal(ns, ident, def),
-            NsMap(gs, ls(EmptyParen, lss)) ident def => (NsMap(gs, (:((:((ident, def), ls)), lss))), Prelude.lookup(ident, ls)),
-        }
-    }
-
-    fn enterNewScope(NsMap(gs, lss): NameSpaceMap(k, a)) -> NameSpaceMap(k, a) {
-        NsMap(gs, (:(vec![], lss)))
-    }
-
-    fn globalNames(NsMap(g, _): NameSpaceMap(k, v)) -> Map(k, v) {
-        g
-    }
-
-    fn hasLocalNames(NsMap(_, l): NameSpaceMap(k, v)) -> Bool {
-        not((null(l)))
-    }
-
-    fn leaveScope(__0: NameSpaceMap(k, a)) -> (NameSpaceMap(k, a), Vec<(k, a)>) {
-        match (__0) {
-            NsMap(_, Vec<>) => error("NsMaps.leaveScope: No local scope!".to_string()),
-            NsMap(gs, ls(EmptyParen, lss)) => (NsMap(gs, lss), ls),
-        }
-    }
-
-    fn localNames(NsMap(_, l): NameSpaceMap(k, v)) -> Vec<Vec<(k, v)>> {
-        l
-    }
-
-    fn lookupGlobal(NsMap(gs, _): NameSpaceMap(k, a), ident: k) -> Maybe(a) {
-        Map.lookup(ident, gs)
-    }
-
-    fn lookupInnermostScope(nsm: NameSpaceMap(k, a), EmptyParen: k, NsMap(_gs, localDefs): Maybe(a)) -> Maybe(a) {
-        match localDefs {
-                ls(EmptyParen, _lss) => Prelude.lookup(ident, ls),
-                Vec<> => lookupGlobal(nsm, ident),
-            }
-    }
-
-    fn lookupName(ns: NameSpaceMap(k, a), EmptyParen: k, NsMap(_, localDefs): Maybe(a)) -> Maybe(a) {
-        match (lookupLocal(localDefs)) {
-                Nothing => lookupGlobal(ns, ident),
-                Just def => Just(def),
-            }
-    }
-
-    fn mergeNameSpace(NsMap(global1, local1): NameSpaceMap(k, a), NsMap(global2, local2): NameSpaceMap(k, a)) -> NameSpaceMap(k, a) {
-        NsMap((Map.union(global1, global2)), (localUnion(local1, local2)))
-    }
-
-    fn nameSpaceMap() -> NameSpaceMap(k, v) {
-        NsMap(Map.empty, vec![])
-    }
-
-    fn nsMapToList(NsMap(gs, lss): NameSpaceMap(k, a)) -> Vec<(k, a)> {
-        ++(concat(lss), Map.toList(gs))
-    }
-
-}
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/Export.hs"
+Error: Unrecognized token `->`:
+ 35 |     (specs,derived) = exportType ty
+ 36 |      ;(ident,asmname) = case name of{ (VarName vident asmname_opt) ->
+ 37 |                                      _ -> (Nothing,Nothing)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/NameSpaceMap.hs"
+Error: Unrecognized token `=`:
+152 |   where{ localUnion (l1:ls1) (l2:ls2) =
+153 |            List.unionBy (\p1 p2 -> fst p1 == fst p2) l1 l2 : localUnio
+154 |          localUnion [] ls2 = ls2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Analysis_SemError {
     #[derive(Debug)]
     struct RedefError(RedefError, ErrorLevel, RedefInfo);
@@ -805,15 +514,15 @@ mod Language_C_Analysis_SemError {
 
     fn redefErrReason(__0: RedefInfo) -> String {
         match (__0) {
-            RedefInfo(ident, DuplicateDef, _, _) => ++("duplicate definition of ".to_string(), ident),
-            RedefInfo(ident, ShadowedDef, _, _) => ++("this declaration of ".to_string(), ++(ident, " shadows a previous one".to_string())),
-            RedefInfo(ident, DiffKindRedecl, _, _) => ++(ident, " previously declared as a different kind of symbol".to_string()),
-            RedefInfo(ident, DisagreeLinkage, _, _) => ++(ident, " previously declared with different linkage".to_string()),
-            RedefInfo(ident, NoLinkageOld, _, _) => ++(ident, " previously declared without linkage".to_string()),
+            RedefInfo(ident, DuplicateDef, _, _) => { ++("duplicate definition of ".to_string(), ident) },
+            RedefInfo(ident, ShadowedDef, _, _) => { ++("this declaration of ".to_string(), ++(ident, " shadows a previous one".to_string())) },
+            RedefInfo(ident, DiffKindRedecl, _, _) => { ++(ident, " previously declared as a different kind of symbol".to_string()) },
+            RedefInfo(ident, DisagreeLinkage, _, _) => { ++(ident, " previously declared with different linkage".to_string()) },
+            RedefInfo(ident, NoLinkageOld, _, _) => { ++(ident, " previously declared without linkage".to_string()) },
         }
     }
 
-    fn redefErrorInfo(lvl: ErrorLevel, info: RedefInfo, EmptyParen: ErrorInfo) -> ErrorInfo {
+    fn redefErrorInfo(lvl: ErrorLevel, info: RedefInfo, <todo>: ErrorInfo) -> ErrorInfo {
         ErrorInfo(lvl, (posOfNode(node)), (++(vec![redefErrReason(info)], prevDeclMsg(old_node))))
     }
 
@@ -838,7 +547,7 @@ mod Language_C_Analysis_SemRep {
     #[derive(Debug, Clone)]
     struct IdentDecl(Declaration, Decl, ObjectDef, ObjDef, FunctionDef, FunDef, EnumeratorDef, Enumerator);
 
-    struct GlobalDecls(GlobalDecls, RecordTODO);
+    struct GlobalDecls(GlobalDecls, { /* struct def */ });
 
     #[derive()]
     struct DeclEvent(TagEvent, TagDef, DeclEvent, IdentDecl, ParamEvent, ParamDecl, LocalEvent, IdentDecl, TypeDefEvent, TypeDef, AsmEvent, AsmBlock);
@@ -916,7 +625,7 @@ mod Language_C_Analysis_SemRep {
     struct Enumerator(Enumerator, Ident, Expr, EnumType, NodeInfo);
 
     #[derive(Debug, Clone)]
-    struct TypeQuals(TypeQuals, RecordTODO);
+    struct TypeQuals(TypeQuals, { /* struct def */ });
 
     #[derive(Debug, Clone)]
     struct VarName(VarName, Ident, Maybe(AsmName), NoName);
@@ -934,10 +643,10 @@ mod Language_C_Analysis_SemRep {
 
     fn declLinkage(decl: d) -> Linkage {
         match declStorage(decl) {
-                NoStorage => undefined,
-                Auto _ => NoLinkage,
-                Static linkage _ => linkage,
-                FunLinkage linkage => linkage,
+                NoStorage => { undefined },
+                Auto, _ => { NoLinkage },
+                Static, linkage, _ => { linkage },
+                FunLinkage, linkage => { linkage },
             }
     }
 
@@ -951,7 +660,7 @@ mod Language_C_Analysis_SemRep {
 
     fn declStorage(d: d) -> Storage {
         match declAttrs(d) {
-                DeclAttrs(_, st, _) => st,
+                DeclAttrs(_, st, _) => { st },
             }
     }
 
@@ -963,7 +672,7 @@ mod Language_C_Analysis_SemRep {
         GlobalDecls(Map.empty, Map.empty, Map.empty)
     }
 
-    fn filterGlobalDecls(decl_filter: Pair(Span([Ref(Ident("DeclEvent"))]), Span([Ref(Ident("Bool"))])), gmap: GlobalDecls) -> GlobalDecls {
+    fn filterGlobalDecls(decl_filter: fn(DeclEvent) -> Bool, gmap: GlobalDecls) -> GlobalDecls {
         GlobalDecls(hashmap! {
             "gObjs" => Map.filter(((decl_filter . DeclEvent)), (gObjs(gmap))),
             "gTags" => Map.filter(((decl_filter . TagEvent)), (gTags(gmap))),
@@ -973,9 +682,9 @@ mod Language_C_Analysis_SemRep {
 
     fn hasLinkage(__0: Storage) -> Bool {
         match (__0) {
-            Auto(_) => False,
-            Static(NoLinkage, _) => False,
-            _ => True,
+            Auto(_) => { False },
+            Static(NoLinkage, _) => { False },
+            _ => { True },
         }
     }
 
@@ -985,8 +694,8 @@ mod Language_C_Analysis_SemRep {
 
     fn identOfVarName(__0: VarName) -> Ident {
         match (__0) {
-            NoName => error("identOfVarName: NoName".to_string()),
-            VarName(ident, _) => ident,
+            NoName => { error("identOfVarName: NoName".to_string()) },
+            VarName(ident, _) => { ident },
         }
     }
 
@@ -996,8 +705,8 @@ mod Language_C_Analysis_SemRep {
 
     fn isNoName(__0: VarName) -> Bool {
         match (__0) {
-            NoName => True,
-            _ => False,
+            NoName => { True },
+            _ => { False },
         }
     }
 
@@ -1027,10 +736,10 @@ mod Language_C_Analysis_SemRep {
 
     fn objKindDescr(__0: IdentDecl) -> String {
         match (__0) {
-            Declaration(_) => "declaration".to_string(),
-            ObjectDef(_) => "object definition".to_string(),
-            FunctionDef(_) => "function definition".to_string(),
-            EnumeratorDef(_) => "enumerator definition".to_string(),
+            Declaration(_) => { "declaration".to_string() },
+            ObjectDef(_) => { "object definition".to_string() },
+            FunctionDef(_) => { "function definition".to_string() },
+            EnumeratorDef(_) => { "enumerator definition".to_string() },
         }
     }
 
@@ -1048,33 +757,43 @@ mod Language_C_Analysis_SemRep {
 
     fn typeOfTagDef(__0: TagDef) -> TypeName {
         match (__0) {
-            CompDef(comptype) => typeOfCompDef(comptype),
-            EnumDef(enumtype) => typeOfEnumDef(enumtype),
+            CompDef(comptype) => { typeOfCompDef(comptype) },
+            EnumDef(enumtype) => { typeOfEnumDef(enumtype) },
         }
     }
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/TravMonad.hs"
-
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/TypeCheck.hs"
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/TravMonad.hs"
+Error: Unrecognized token `->`:
+372 |
+373 |
+374 | ;newtype Trav s a = Trav { unTrav :: TravState s -> Either CError (a,
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/TypeCheck.hs"
+Error: Unrecognized token `|`:
+ 95 |   do{ n <- genName
+ 96 |       let{ charType | wide      = TyInt
+ 97 |                     | otherwise = TyChar
+~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Analysis_TypeConversions {
     fn arithmeticConversion(__0: TypeName, __1: TypeName) -> Maybe(TypeName) {
         match (__0, __1) {
-            TyComplex(t1) TyComplex(t2) => Just(TyComplex(floatConversion(t1, t2))),
-            TyComplex(t1) TyFloating(t2) => Just(TyComplex(floatConversion(t1, t2))),
-            TyFloating(t1) TyComplex(t2) => Just(TyComplex(floatConversion(t1, t2))),
-            t1 EmptyParen TyComplex(_) TyIntegral(_) => Just(t1),
-            TyIntegral(_) t2 EmptyParen TyComplex(_) => Just(t2),
-            TyFloating(t1) TyFloating(t2) => Just(TyFloating(floatConversion(t1, t2))),
-            t1 EmptyParen TyFloating(_) TyIntegral(_) => Just(t1),
-            TyIntegral(_) t2 EmptyParen TyFloating(_) => Just(t2),
-            TyIntegral(t1) TyIntegral(t2) => Just(TyIntegral(intConversion(t1, t2))),
-            TyEnum(_) TyEnum(_) => Just(TyIntegral(TyInt)),
-            TyEnum(_) t2 => Just(t2),
-            t1 TyEnum(_) => Just(t1),
-            _ _ => Nothing,
+            TyComplex(t1), TyComplex(t2) => { Just(TyComplex(floatConversion(t1, t2))) },
+            TyComplex(t1), TyFloating(t2) => { Just(TyComplex(floatConversion(t1, t2))) },
+            TyFloating(t1), TyComplex(t2) => { Just(TyComplex(floatConversion(t1, t2))) },
+            t1, <todo>, TyComplex(_), TyIntegral(_) => { Just(t1) },
+            TyIntegral(_), t2, <todo>, TyComplex(_) => { Just(t2) },
+            TyFloating(t1), TyFloating(t2) => { Just(TyFloating(floatConversion(t1, t2))) },
+            t1, <todo>, TyFloating(_), TyIntegral(_) => { Just(t1) },
+            TyIntegral(_), t2, <todo>, TyFloating(_) => { Just(t2) },
+            TyIntegral(t1), TyIntegral(t2) => { Just(TyIntegral(intConversion(t1, t2))) },
+            TyEnum(_), TyEnum(_) => { Just(TyIntegral(TyInt)) },
+            TyEnum(_), t2 => { Just(t2) },
+            t1, TyEnum(_) => { Just(t1) },
+            _, _ => { Nothing },
         }
     }
 
@@ -1088,8 +807,13 @@ mod Language_C_Analysis_TypeConversions {
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/TypeUtils.hs"
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Analysis/TypeUtils.hs"
+Error: Unrecognized token `->`:
+136 | ;isFunctionType ty =
+137 |     case ty of{  TypeDefType (TypeDefRef _ (Just actual_ty) _) _ _ ->
+138 |                  TypeDefType _ _ _ -> error "aXNGdW5jdGlvblR5cGU6IHVuc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Analysis {
 
 }
@@ -1148,7 +872,7 @@ mod Language_C_Data_Error {
     }
 
     fn showErrorInfo(short_msg: String, ErrorInfo(level, pos, msgs): ErrorInfo) -> String {
-        ++(header, showMsgLines((:(if(null, short_msg, then, msgs, else, short_msg), msgs))))
+        ++(header, showMsgLines((if(null, short_msg, then, msgs, else, short_msg:msgs))))
     }
 
     fn unsupportedFeature(msg: String, a: a) -> UnsupportedFeature {
@@ -1210,8 +934,8 @@ mod Language_C_Data_Ident {
 
     fn isAnonymousRef(__0: SUERef) -> Bool {
         match (__0) {
-            AnonymousRef(_) => True,
-            _ => False,
+            AnonymousRef(_) => { True },
+            _ => { False },
         }
     }
 
@@ -1225,11 +949,11 @@ mod Language_C_Data_Ident {
 
     fn quad(__0: String) -> isize {
         match (__0) {
-            c1(EmptyParen, c2, EmptyParen, c3, EmptyParen, c4, EmptyParen, s) => +((mod((*(ord(c4), +(bits21, *(ord(c3), +(bits14, *(ord(c2), +(bits7, ord(c1)))))))), bits28)), (mod(quad(s), bits28))),
-            c1(EmptyParen, c2, EmptyParen, c3, EmptyParen, Vec<>) => *(ord(c3), +(bits14, *(ord(c2), +(bits7, ord(c1))))),
-            c1(EmptyParen, c2, EmptyParen, Vec<>) => *(ord(c2), +(bits7, ord(c1))),
-            c1(EmptyParen, Vec<>) => ord(c1),
-            Vec<> => 0,
+            c1:c2:c3:c4:s => { +((mod((*(ord(c4), +(bits21, *(ord(c3), +(bits14, *(ord(c2), +(bits7, ord(c1)))))))), bits28)), (mod(quad(s), bits28))) },
+            c1:c2:c3:([]) => { *(ord(c3), +(bits14, *(ord(c2), +(bits7, ord(c1))))) },
+            c1:c2:([]) => { *(ord(c2), +(bits7, ord(c1))) },
+            c1:([]) => { ord(c1) },
+            [] => { 0 },
         }
     }
 
@@ -1238,36 +962,36 @@ mod Language_C_Data_Ident {
 mod Language_C_Data_InputStream {
     fn countLines() -> isize {
         match () {
-             => (length . BSC.lines),
-             => (length . lines),
+             => { (length . BSC.lines) },
+             => { (length . lines) },
         }
     }
 
     fn inputStreamEmpty() -> Bool {
         match () {
-             => BSW.null,
-             => null,
+             => { BSW.null },
+             => { null },
         }
     }
 
     fn inputStreamFromString() -> InputStream {
         match () {
-             => BSC.pack,
-             => id,
+             => { BSC.pack },
+             => { id },
         }
     }
 
     fn inputStreamToString() -> String {
         match () {
-             => BSC.unpack,
-             => id,
+             => { BSC.unpack },
+             => { id },
         }
     }
 
     fn readInputStream() -> IO(InputStream) {
         match () {
-             => BSW.readFile,
-             => readFile,
+             => { BSW.readFile },
+             => { readFile },
         }
     }
 
@@ -1277,15 +1001,15 @@ mod Language_C_Data_InputStream {
 
     fn takeChar(__0: InputStream) -> (Char, InputStream) {
         match (__0) {
-            bs => seq(BSC.head(bs), (BSC.head(bs), BSC.tail(bs))),
-            bs => (head(bs), tail(bs)),
+            bs => { seq(BSC.head(bs), (BSC.head(bs), BSC.tail(bs))) },
+            bs => { (head(bs), tail(bs)) },
         }
     }
 
     fn takeChars(__0: isize, __1: InputStream) -> Vec<Char> {
         match (__0, __1) {
-            n bstr => BSC.unpack(BSC.take(n, bstr)),
-            n str => take(n, str),
+            n, bstr => { BSC.unpack(BSC.take(n, bstr)) },
+            n, str => { take(n, str) },
         }
     }
 
@@ -1302,16 +1026,21 @@ mod Language_C_Data_Name {
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Data/Node.hs"
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Data/Node.hs"
+Error: Unrecognized token `->`:
+ 56 |     where{
+ 57 |     len = case ni of{ NodeInfo firstPos lastTok _ -> computeLength fir
+ 58 |                        OnlyPos firstPos lastTok -> computeLength first
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Data_Position {
     #[derive(Eq, Ord, Debug, Clone)]
-    struct Position(Position, RecordTODO, NoPosition, BuiltinPosition, InternalPosition);
+    struct Position(Position, { /* struct def */ }, NoPosition, BuiltinPosition, InternalPosition);
 
     fn adjustPos(__0: FilePath, __1: isize, __2: Position) -> Position {
         match (__0, __1, __2) {
-            fname row Position(offs, _, _, _) => Position(offs, fname, row, 1),
-            _ _ p => p,
+            fname, row, Position(offs, _, _, _) => { Position(offs, fname, row, 1) },
+            _, _, p => { p },
         }
     }
 
@@ -1321,15 +1050,15 @@ mod Language_C_Data_Position {
 
     fn incOffset(__0: Position, __1: isize) -> Position {
         match (__0, __1) {
-            Position(o, f, r, c) n => Position((+(o, n)), f, r, c),
-            p n => p,
+            Position(o, f, r, c), n => { Position((+(o, n)), f, r, c) },
+            p, n => { p },
         }
     }
 
     fn incPos(__0: Position, __1: isize) -> Position {
         match (__0, __1) {
-            Position(offs, fname, row, col) n => Position((+(offs, n)), fname, row, (+(col, n))),
-            p _ => p,
+            Position(offs, fname, row, col), n => { Position((+(offs, n)), fname, row, (+(col, n))) },
+            p, _ => { p },
         }
     }
 
@@ -1343,29 +1072,29 @@ mod Language_C_Data_Position {
 
     fn isBuiltinPos(__0: Position) -> Bool {
         match (__0) {
-            BuiltinPosition => True,
-            _ => False,
+            BuiltinPosition => { True },
+            _ => { False },
         }
     }
 
     fn isInternalPos(__0: Position) -> Bool {
         match (__0) {
-            InternalPosition => True,
-            _ => False,
+            InternalPosition => { True },
+            _ => { False },
         }
     }
 
     fn isNoPos(__0: Position) -> Bool {
         match (__0) {
-            NoPosition => True,
-            _ => False,
+            NoPosition => { True },
+            _ => { False },
         }
     }
 
     fn isSourcePos(__0: Position) -> Bool {
         match (__0) {
-            Position(_, _, _, _) => True,
-            _ => False,
+            Position(_, _, _, _) => { True },
+            _ => { False },
         }
     }
 
@@ -1379,14 +1108,54 @@ mod Language_C_Data_Position {
 
     fn retPos(__0: Position) -> Position {
         match (__0) {
-            Position(offs, fname, row, _) => Position((+(offs, 1)), fname, (+(row, 1)), 1),
-            p => p,
+            Position(offs, fname, row, _) => { Position((+(offs, 1)), fname, (+(row, 1)), 1) },
+            p => { p },
         }
     }
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Data/RList.hs"
+mod Language_C_Data_RList {
+    fn appendr(xs: Vec<a>, Reversed(ys): Reversed(Vec<a>)) -> Reversed(Vec<a>) {
+        Reversed((++(ys, List.reverse(xs))))
+    }
+
+    fn empty() -> Reversed(Vec<a>) {
+        Reversed(vec![])
+    }
+
+    fn rappend(Reversed(xs): Reversed(Vec<a>), ys: Vec<a>) -> Reversed(Vec<a>) {
+        Reversed((++(List.reverse(ys), xs)))
+    }
+
+    fn rappendr(Reversed(xs): Reversed(Vec<a>), Reversed(ys): Reversed(Vec<a>)) -> Reversed(Vec<a>) {
+        Reversed((++(ys, xs)))
+    }
+
+    fn reverse(Reversed(xs): Reversed(Vec<a>)) -> Vec<a> {
+        List.reverse(xs)
+    }
+
+    fn rmap(f: fn(a) -> b, Reversed(xs): Reversed(Vec<a>)) -> Reversed(Vec<b>) {
+        Reversed((map(f, xs)))
+    }
+
+    fn singleton(x: a) -> Reversed(Vec<a>) {
+        Reversed(vec![x])
+    }
+
+    fn snoc(Reversed(xs): Reversed(Vec<a>), x: a) -> Reversed(Vec<a>) {
+        Reversed((:(x, xs)))
+    }
+
+    fn viewr(__0: Reversed(Vec<a>)) -> (Reversed(Vec<a>), a) {
+        match (__0) {
+            Reversed([]) => { error("viewr: empty RList".to_string()) },
+            Reversed(x:xs) => { (Reversed(xs), x) },
+        }
+    }
+
+}
 
 mod Language_C_Data {
 
@@ -1399,10 +1168,20 @@ mod Language_C_Parser_Builtin {
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Parser/ParserMonad.hs"
-
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Parser/Tokens.hs"
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Parser/ParserMonad.hs"
+Error: Unrecognized token `CTokEof`:
+ 45 | ;import Language.C.Data.Name    (Name)
+ 46 | ;import Language.C.Data.Ident    (Ident)
+ 47 | ;import Language.C.Parser.Tokens (CToken(CTokEof))
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Parser/Tokens.hs"
+Error: Unrecognized token `|`:
+255 |    ;showsPrec _ (CTokTilde    _  ) = showString "fg=="
+256 |    ;showsPrec _ (CTokInc      _  ) = showString "Kys="
+257 | QcmVjIF8gKENUb2tCYXIgICAgICBfICApID0gc2hvd1N0cmluZyA="|"CiAgc2hvd3NQcm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Parser {
     fn execParser_(parser: P(a), input: InputStream, pos: Position) -> Either(ParseError, a) {
         fmap(fst)(execParser(parser, input, pos, builtinTypeNames, newNameSupply))
@@ -1410,8 +1189,13 @@ mod Language_C_Parser {
 
 }
 
-// ERROR: cannot yet convert file "./language-c/src/Language/C/Pretty.hs"
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Pretty.hs"
+Error: Unrecognized token `->`:
+384 |          parenPrec p 26 $ prettyPrec 26 expr <> text "Kys="
+385 |      ;prettyPrec p (CUnary CPostDecOp expr _) =
+386 | gICAgICAgICAgICAgICA8PiB0ZXh0IChpZiBkZXJlZiB0aGVuIA=="->"IGVsc2Ug"."KS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Syntax_AST {
     #[derive(Show, Clone, Debug)]
     struct CTranslationUnit(CTranslUnit, Vec<CExternalDeclaration(a)>, a);
@@ -1492,15 +1276,15 @@ mod Language_C_Syntax_AST {
         cstr
     }
 
-    fn fmapInitList(_f: Pair(Span([Ref(Ident("a"))]), Span([Ref(Ident("b"))]))) -> CInitializerList(b) {
+    fn fmapInitList(_f: fn(a) -> b) -> CInitializerList(b) {
         map((Lambda))
     }
 
     fn isSUEDef(__0: CTypeSpecifier(a)) -> Bool {
         match (__0) {
-            CSUType(CStruct(_, _, Just(_), _, _), _) => True,
-            CEnumType(CEnum(_, Just(_), _, _), _) => True,
-            _ => False,
+            CSUType(CStruct(_, _, Just(_), _, _), _) => { True },
+            CEnumType(CEnum(_, Just(_), _, _), _) => { True },
+            _ => { False },
         }
     }
 
@@ -1514,223 +1298,13 @@ mod Language_C_Syntax_AST {
 
 }
 
-mod Language_C_Syntax_Constants {
-    #[derive(Eq, Ord, Clone, Debug)]
-    struct CChar(CChar, Char, Bool, CChars, Vec<Char>, Bool);
-
-    #[derive(Eq, Ord, Enum, Bounded, Clone, Debug)]
-    struct CIntRepr(DecRepr, HexRepr, OctalRepr);
-
-    #[derive(Eq, Ord, Enum, Bounded, Clone, Debug)]
-    struct CIntFlag(FlagUnsigned, FlagLong, FlagLongLong, FlagImag);
-
-    #[derive(Eq, Ord, Clone, Debug)]
-    struct CInteger(CInteger, Integer, CIntRepr, Flags(CIntFlag));
-
-    #[derive(Eq, Ord, Clone, Debug)]
-    struct CFloat(CFloat, String);
-
-    #[derive(Eq, Ord, Clone, Debug)]
-    struct CString(CString, Vec<Char>, Bool);
-
-    fn _showWideFlag(flag: Bool) -> ShowS {
-        if(flag, then, showString, "L".to_string(), else, id)
-    }
-
-    fn cChar(c: Char) -> CChar {
-        CChar(c, False)
-    }
-
-    fn cChar_w(c: Char) -> CChar {
-        CChar(c, True)
-    }
-
-    fn cChars() -> CChar {
-        CChars
-    }
-
-    fn cFloat() -> CFloat {
-        (CFloat . show)
-    }
-
-    fn cInteger(i: Integer) -> CInteger {
-        CInteger(i, DecRepr, noFlags)
-    }
-
-    fn cString(str: String) -> CString {
-        CString(str, False)
-    }
-
-    fn cString_w(str: String) -> CString {
-        CString(str, True)
-    }
-
-    fn clearFlag(flag: f, Flags(k): Flags(f)) -> Flags(f) {
-        Flags(clearBit(k, fromEnum(flag)))
-    }
-
-    fn concatCStrings(cs: Vec<CString>) -> CString {
-        CString((concatMap(getCString, cs)), (any(isWideString, cs)))
-    }
-
-    fn dQuote(s: String, t: ShowS) -> ShowS {
-        ++((:("\"\"".to_string(), s)), ++("\\\"".to_string(), t))
-    }
-
-    fn escapeCChar("@@WEIRD BAD BASE64 STR@@": Char) -> String {
-        "\\\\\'".to_string()
-    }
-
-    fn escapeChar(__0: Char) -> String {
-        match (__0) {
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\\\\\".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\a".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\b".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\e".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\f".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\n".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\r".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\t".to_string(),
-            "@@WEIRD BAD BASE64 STR@@" => "\\\\v".to_string(),
-        }
-    }
-
-    fn getCChar(__0: CChar) -> Vec<Char> {
-        match (__0) {
-            CChar(c, _) => vec![c],
-            CChars(cs, _) => cs,
-        }
-    }
-
-    fn getCCharAsInt(__0: CChar) -> Integer {
-        match (__0) {
-            CChar(c, _) => fromIntegral((fromEnum(c))),
-            CChars(_cs, _) => error("integer value of multi-character character constants is implementation defined".to_string()),
-        }
-    }
-
-    fn getCInteger(CInteger(i, _, _): CInteger) -> Integer {
-        i
-    }
-
-    fn getCString(CString(str, _): CString) -> String {
-        str
-    }
-
-    fn head'(__0: String, __1: Vec<a>) -> a {
-        match (__0, __1) {
-            err Vec<> => error(err),
-            _ x(EmptyParen, _) => x,
-        }
-    }
-
-    fn isAsciiSourceChar(c: Char) -> Bool {
-        &&(isAscii(c), isPrint(c))
-    }
-
-    fn isCChar(__0: Char) -> Bool {
-        match (__0) {
-            "@@WEIRD BAD BASE64 STR@@" => False,
-            "@@WEIRD BAD BASE64 STR@@" => False,
-            "@@WEIRD BAD BASE64 STR@@" => False,
-            c => isAsciiSourceChar(c),
-        }
-    }
-
-    fn isSChar(__0: Char) -> Bool {
-        match (__0) {
-            "@@WEIRD BAD BASE64 STR@@" => False,
-            "@@WEIRD BAD BASE64 STR@@" => False,
-            "@@WEIRD BAD BASE64 STR@@" => False,
-            c => isAsciiSourceChar(c),
-        }
-    }
-
-    fn isWideChar(__0: CChar) -> Bool {
-        match (__0) {
-            CChar(_, wideFlag) => wideFlag,
-            CChars(_, wideFlag) => wideFlag,
-        }
-    }
-
-    fn isWideString(CString(_, wideflag): CString) -> Bool {
-        wideflag
-    }
-
-    fn noFlags() -> Flags(f) {
-        Flags(0)
-    }
-
-    fn readCFloat() -> CFloat {
-        CFloat
-    }
-
-    fn readCInteger(repr: CIntRepr, str: String) -> Either(String, CInteger) {
-        match readNum(str) {
-                Vec<(n, suffix)> => mkCInt(n, suffix),
-                parseFailed => Left(++("Bad Integer literal: ".to_string(), show(parseFailed))),
-            }
-    }
-
-    fn sQuote(s: String, t: ShowS) -> ShowS {
-        ++("\'".to_string(), ++(s, ++("\'".to_string(), t)))
-    }
-
-    fn setFlag(flag: f, Flags(k): Flags(f)) -> Flags(f) {
-        Flags(setBit(k, fromEnum(flag)))
-    }
-
-    fn showCharConst(c: Char) -> ShowS {
-        sQuote(escapeCChar(c))
-    }
-
-    fn showStringLit() -> ShowS {
-        (dQuote . concatMap(showStringChar))
-    }
-
-    fn testFlag(flag: f, Flags(k): Flags(f)) -> Bool {
-        testBit(k, fromEnum(flag))
-    }
-
-    fn unescapeChar(__0: String) -> (Char, String) {
-        match (__0) {
-            "@@WEIRD BAD BASE64 STR@@"(EmptyParen, c, EmptyParen, cs) => match c {
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => ("\"\"".to_string(), cs),
-                    "@@WEIRD BAD BASE64 STR@@" => match head'("bad escape sequence".to_string(), (readHex(cs))) {
-                            (i, cs') => (toEnum(i), cs'),
-                        },
-                    _ => match head'("bad escape sequence".to_string(), (readOct((:(c, cs))))) {
-                            (i, cs') => (toEnum(i), cs'),
-                        },
-                },
-            c(EmptyParen, cs) => (c, cs),
-            Vec<> => error("unescape char: empty string".to_string()),
-        }
-    }
-
-    fn unescapeString(__0: String) -> String {
-        match (__0) {
-            Vec<> => vec![],
-            cs => match unescapeChar(cs) {
-                    (c, cs') => :(c, unescapeString(cs')),
-                },
-        }
-    }
-
-}
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/Syntax/Constants.hs"
+Error: Unrecognized token `->`:
+107 |          showIFlag f = if testFlag f flags then show f else []
+108 |           ;showInt i = case repr of{ DecRepr -> shows i
+109 |                                     OctalRepr -> showString "MA==" . s
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_Syntax_Ops {
     #[derive(Eq, Ord, Show, Clone, Debug)]
     struct CAssignOp(CAssignOp, CMulAssOp, CDivAssOp, CRmdAssOp, CAddAssOp, CSubAssOp, CShlAssOp, CShrAssOp, CAndAssOp, CXorAssOp, COrAssOp);
@@ -1743,17 +1317,17 @@ mod Language_C_Syntax_Ops {
 
     fn assignBinop(__0: CAssignOp) -> CBinaryOp {
         match (__0) {
-            CAssignOp => error("direct assignment has no binary operator".to_string()),
-            CMulAssOp => CMulOp,
-            CDivAssOp => CDivOp,
-            CRmdAssOp => CRmdOp,
-            CAddAssOp => CAddOp,
-            CSubAssOp => CSubOp,
-            CShlAssOp => CShlOp,
-            CShrAssOp => CShrOp,
-            CAndAssOp => CAndOp,
-            CXorAssOp => CXorOp,
-            COrAssOp => COrOp,
+            CAssignOp => { error("direct assignment has no binary operator".to_string()) },
+            CMulAssOp => { CMulOp },
+            CDivAssOp => { CDivOp },
+            CRmdAssOp => { CRmdOp },
+            CAddAssOp => { CAddOp },
+            CSubAssOp => { CSubOp },
+            CShlAssOp => { CShlOp },
+            CShrAssOp => { CShrOp },
+            CAndAssOp => { CAndOp },
+            CXorAssOp => { CXorOp },
+            COrAssOp => { COrOp },
         }
     }
 
@@ -1782,60 +1356,60 @@ mod Language_C_Syntax_Ops {
 mod Language_C_Syntax_Utils {
     fn compoundSubStmts(__0: CBlockItem) -> Vec<CStat> {
         match (__0) {
-            CBlockStmt(s) => vec![s],
-            CBlockDecl(_) => vec![],
-            CNestedFunDef(_) => vec![],
+            CBlockStmt(s) => { vec![s] },
+            CBlockDecl(_) => { vec![] },
+            CNestedFunDef(_) => { vec![] },
         }
     }
 
     fn getLabels(__0: CStat) -> Vec<Ident> {
         match (__0) {
-            CLabel(l, s, _, _) => :(l, getLabels(s)),
-            CCompound(ls, body, _) => \\(concatMap(((concatMap(getLabels) . compoundSubStmts)), body), ls),
-            stmt => concatMap(getLabels, (getSubStmts(stmt))),
+            CLabel(l, s, _, _) => { :(l, getLabels(s)) },
+            CCompound(ls, body, _) => { \\(concatMap(((concatMap(getLabels) . compoundSubStmts)), body), ls) },
+            stmt => { concatMap(getLabels, (getSubStmts(stmt))) },
         }
     }
 
     fn getSubStmts(__0: CStat) -> Vec<CStat> {
         match (__0) {
-            CLabel(_, s, _, _) => vec![s],
-            CCase(_, s, _) => vec![s],
-            CCases(_, _, s, _) => vec![s],
-            CDefault(s, _) => vec![s],
-            CExpr(_, _) => vec![],
-            CCompound(_, body, _) => concatMap(compoundSubStmts, body),
-            CIf(_, sthen, selse, _) => maybe(vec![sthen], (Lambda), selse),
-            CSwitch(_, s, _) => vec![s],
-            CWhile(_, s, _, _) => vec![s],
-            CFor(_, _, _, s, _) => vec![s],
-            CGoto(_, _) => vec![],
-            CGotoPtr(_, _) => vec![],
-            CCont(_) => vec![],
-            CBreak(_) => vec![],
-            CReturn(_, _) => vec![],
-            CAsm(_, _) => vec![],
+            CLabel(_, s, _, _) => { vec![s] },
+            CCase(_, s, _) => { vec![s] },
+            CCases(_, _, s, _) => { vec![s] },
+            CDefault(s, _) => { vec![s] },
+            CExpr(_, _) => { vec![] },
+            CCompound(_, body, _) => { concatMap(compoundSubStmts, body) },
+            CIf(_, sthen, selse, _) => { maybe(vec![sthen], (Lambda), selse) },
+            CSwitch(_, s, _) => { vec![s] },
+            CWhile(_, s, _, _) => { vec![s] },
+            CFor(_, _, _, s, _) => { vec![s] },
+            CGoto(_, _) => { vec![] },
+            CGotoPtr(_, _) => { vec![] },
+            CCont(_) => { vec![] },
+            CBreak(_) => { vec![] },
+            CReturn(_, _) => { vec![] },
+            CAsm(_, _) => { vec![] },
         }
     }
 
-    fn mapBlockItemStmts(__0: Pair(Span([Ref(Ident("CStat"))]), Span([Ref(Ident("Bool"))])), __1: Pair(Span([Ref(Ident("CStat"))]), Span([Ref(Ident("CStat"))])), __2: CBlockItem) -> CBlockItem {
+    fn mapBlockItemStmts(__0: fn(CStat) -> Bool, __1: fn(CStat) -> CStat, __2: CBlockItem) -> CBlockItem {
         match (__0, __1, __2) {
-            stop f CBlockStmt(s) => CBlockStmt((mapSubStmts(stop, f, s))),
-            _ _ bi => bi,
+            stop, f, CBlockStmt(s) => { CBlockStmt((mapSubStmts(stop, f, s))) },
+            _, _, bi => { bi },
         }
     }
 
-    fn mapSubStmts(__0: Pair(Span([Ref(Ident("CStat"))]), Span([Ref(Ident("Bool"))])), __1: Pair(Span([Ref(Ident("CStat"))]), Span([Ref(Ident("CStat"))])), __2: CStat) -> CStat {
+    fn mapSubStmts(__0: fn(CStat) -> Bool, __1: fn(CStat) -> CStat, __2: CStat) -> CStat {
         match (__0, __1, __2) {
-            stop f CLabel(i, s, attrs, ni) => f((CLabel(i, (mapSubStmts(stop, f, s)), attrs, ni))),
-            stop f CCase(e, s, ni) => f((CCase(e, (mapSubStmts(stop, f, s)), ni))),
-            stop f CCases(e1, e2, s, ni) => f((CCases(e1, e2, (mapSubStmts(stop, f, s)), ni))),
-            stop f CDefault(s, ni) => f((CDefault((mapSubStmts(stop, f, s)), ni))),
-            stop f CCompound(ls, body, ni) => f((CCompound(ls, (map((mapBlockItemStmts(stop, f)), body)), ni))),
-            stop f CIf(e, sthen, selse, ni) => f((CIf(e, (mapSubStmts(stop, f, sthen)), (maybe(Nothing, ((Just . mapSubStmts(stop, f))), selse)), ni))),
-            stop f CSwitch(e, s, ni) => f((CSwitch(e, (mapSubStmts(stop, f, s)), ni))),
-            stop f CWhile(e, s, isdo, ni) => f((CWhile(e, (mapSubStmts(stop, f, s)), isdo, ni))),
-            stop f CFor(i, t, a, s, ni) => f((CFor(i, t, a, (mapSubStmts(stop, f, s)), ni))),
-            _ f s => f(s),
+            stop, f, CLabel(i, s, attrs, ni) => { f((CLabel(i, (mapSubStmts(stop, f, s)), attrs, ni))) },
+            stop, f, CCase(e, s, ni) => { f((CCase(e, (mapSubStmts(stop, f, s)), ni))) },
+            stop, f, CCases(e1, e2, s, ni) => { f((CCases(e1, e2, (mapSubStmts(stop, f, s)), ni))) },
+            stop, f, CDefault(s, ni) => { f((CDefault((mapSubStmts(stop, f, s)), ni))) },
+            stop, f, CCompound(ls, body, ni) => { f((CCompound(ls, (map((mapBlockItemStmts(stop, f)), body)), ni))) },
+            stop, f, CIf(e, sthen, selse, ni) => { f((CIf(e, (mapSubStmts(stop, f, sthen)), (maybe(Nothing, ((Just . mapSubStmts(stop, f))), selse)), ni))) },
+            stop, f, CSwitch(e, s, ni) => { f((CSwitch(e, (mapSubStmts(stop, f, s)), ni))) },
+            stop, f, CWhile(e, s, isdo, ni) => { f((CWhile(e, (mapSubStmts(stop, f, s)), isdo, ni))) },
+            stop, f, CFor(i, t, a, s, ni) => { f((CFor(i, t, a, (mapSubStmts(stop, f, s)), ni))) },
+            _, f, s => { f(s) },
         }
     }
 
@@ -1845,34 +1419,17 @@ mod Language_C_Syntax {
 
 }
 
-mod Language_C_System_GCC {
-    fn buildCppArgs(CppArgs(options, extra_args, _tmpdir, input_file, output_file_opt): CppArgs) -> Vec<String> {
-        ++({
-                (concatMap(tOption, options))
-            }, ++(outputFileOpt, ++(vec!["-E".to_string(), input_file], extra_args)))
-    }
-
-    fn gccParseCPPArgs(args: Vec<String>) -> Either(String, (CppArgs, Vec<String>)) {
-        match mungeArgs(((Nothing, Nothing, RList.empty), (RList.empty, RList.empty)), args) {
-                Left err => Left(err),
-                Right ((Nothing, _, _), _) => Left("No .c / .hc / .h source file given".to_string()),
-                Right ((Just(input_file), output_file_opt, cpp_opts), (extra_args, other_args)) => Right(((rawCppArgs((RList.reverse(extra_args)), input_file))(hashmap! {
-                        "outputFile" => output_file_opt,
-                        "cppOptions" => RList.reverse(cpp_opts)
-                        }), RList.reverse(other_args))),
-            }
-    }
-
-    fn newGCC() -> GCC {
-        GCC
-    }
-
-}
-
+/* ERROR: cannot yet convert file "./language-c/src/Language/C/System/GCC.hs"
+Error: Unrecognized token `}`:
+ 38 | rce target = do{ copyFile source target
+ 39 |                  p <- getPermissions target
+ 40 |                  setPermissions target p{writable=True}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+*/
 mod Language_C_System_Preprocess {
     struct CppOption(IncludeDir, FilePath, Define, String, String, Undefine, String, IncludeFile, FilePath);
 
-    struct CppArgs(CppArgs, RecordTODO);
+    struct CppArgs(CppArgs, { /* struct def */ });
 
     fn addCppOption(cpp_args: CppArgs, opt: CppOption) -> CppArgs {
         cpp_args(hashmap! {
@@ -1902,16 +1459,13 @@ mod Language_C_System_Preprocess {
 
     fn mkOutputFile(tmp_dir_opt: Maybe(FilePath), input_file: FilePath) -> IO(FilePath) {
         {
-            let tmpDir = getTempDir(tmp_dir_opt);
-            mkTmpFile(tmpDir, (getOutputFileName(input_file)))
+
         }
     }
 
     fn mkTmpFile(tmp_dir: FilePath, file_templ: FilePath) -> IO(FilePath) {
         {
-            let (path, file_handle) = openTempFile(tmp_dir, file_templ);
-            hClose(file_handle);
-            return(path)
+
         }
     }
 
@@ -1931,27 +1485,7 @@ mod Language_C_System_Preprocess {
 
     fn runPreprocessor(cpp: cpp, cpp_args: CppArgs) -> IO(Either(ExitCode, InputStream)) {
         {
-            fn getActualOutFile() -> IO(FilePath) {
-                maybe((mkOutputFile((cppTmpDir(cpp_args)), (inputFile(cpp_args)))), return, (outputFile(cpp_args)))
-            }
 
-            let invokeCpp = |actual_out_file| {
-                {
-                    let exit_code = runCPP(cpp, (cpp_args(hashmap! {
-                                    "outputFile" => Just(actual_out_file)
-                                    })));
-                    match exit_code {
-                                ExitSuccess => liftM(Right, (readInputStream(actual_out_file))),
-                                ExitFailure _ => return(Left(exit_code)),
-                            }
-                }
-            };
-
-            let removeTmpOutFile = |out_file| {
-                maybe((removeFile(out_file)), (Lambda(())), (outputFile(cpp_args)))
-            };
-
-            bracket(getActualOutFile, removeTmpOutFile, invokeCpp)
         }
     }
 

--- a/out/test.rs
+++ b/out/test.rs
@@ -7,17 +7,17 @@ mod test_module {
 
     fn applyRenames(ident: Ident) -> String {
         match identToString(ident) {
-                "final" => "final_".to_string(),
-                "fn" => "fn_".to_string(),
-                "in" => "in_".to_string(),
-                "let" => "let_".to_string(),
-                "main" => "_c_main".to_string(),
-                "match" => "match_".to_string(),
-                "mod" => "mod_".to_string(),
-                "proc" => "proc_".to_string(),
-                "type" => "type_".to_string(),
-                "where" => "where_".to_string(),
-                name => name,
+                "final" => { "final_".to_string() },
+                "fn" => { "fn_".to_string() },
+                "in" => { "in_".to_string() },
+                "let" => { "let_".to_string() },
+                "main" => { "_c_main".to_string() },
+                "match" => { "match_".to_string() },
+                "mod" => { "mod_".to_string() },
+                "proc" => { "proc_".to_string() },
+                "type" => { "type_".to_string() },
+                "where" => { "where_".to_string() },
+                name => { name },
             }
     }
 

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -19,8 +19,9 @@ pub enum Expr {
 
 #[derive(Clone, Debug)]
 pub enum CaseCond {
-    Matching(Vec<Pat>, Vec<(Expr, Expr)>),
-    Direct(Vec<Pat>, Expr),
+    Matching(Vec<Pat>, Vec<(Vec<Expr>, Expr)>),
+    Direct(Vec<Pat>, Vec<Expr>),
+    Where,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -73,6 +74,7 @@ pub enum Pat {
     Ref(Ident),
     Tuple(Vec<Pat>),
     Brackets(Vec<Pat>),
+    RecordTODO,
     Str(String),
     Num(isize),
     EmptyParen,

--- a/parser/src/calculator.lalrpop
+++ b/parser/src/calculator.lalrpop
@@ -74,7 +74,20 @@ Quote: String = {
 
 
 Ident: Ident = {
-  r"[a-zA-Z_.][.a-zA-Z_0-9']*" => Ident((<>).to_string()),
+  r"[a-zA-Z_.][.a-zA-Z_0-9':=]*" => Ident((<>).to_string()),
+};
+
+Ctor: Ident = {
+    r":[!#$%&*+./<=>?@^|~:\\-]*" => Ident(<>.to_string()),
+};
+
+Operator: String = {
+    r"[!#$%&*+/<=>?@^|~][!#$%&*+./<=>?@^|~:\\-]*" => <>.to_string(),
+    "." => <>.to_string(),
+    ".." => <>.to_string(),
+    ".|." => <>.to_string(),
+    ".&." => <>.to_string(),
+    "-" => <>.to_string(),
 };
 
 Section: i32 = {
@@ -84,8 +97,10 @@ Section: i32 = {
 };
 
 Case: CaseCond = {
-    <d:PatList> <v:("|" <ExprSpan> "->" <ExprSpan>)*> => CaseCond::Matching(d, v),
-    <d:PatList> "->" <v:ExprSpan> => CaseCond::Direct(d, v),
+    // TODO commas can be used in expr spans, see AST.hs
+    <d:PatList> <v:("|" <CommaDef<ExprSpan>> "->" <ExprSpan>)*> => CaseCond::Matching(d, v),
+    <d:PatList> "->" <v:CommaDef<ExprSpan>> ("where" "{" Semi<Statement> "}")? => CaseCond::Direct(d, v),
+    "where" "{" <Semi<Statement>> "}" => CaseCond::Where,
 };
 
 
@@ -98,7 +113,7 @@ Expr: Expr = {
     <Ident> => Expr::Ref(<>),
     Num => Expr::Number(<>),
 
-    "\(" CommaDef<ExprSpan> ")" "->" Expr => Expr::Lambda,
+    r"\\" "(" CommaDef<ExprSpan> ")" "->" Expr => Expr::Lambda,
     "[" <CommaDef<ExprSpan>> "|" CommaDef<ExprSpan> "]" => Expr::Dummy,
     "[" <CommaDef<ExprSpan>> "]" => Expr::Vector(<>),
     "[" "]" => Expr::Vector(vec![]),
@@ -107,43 +122,52 @@ Expr: Expr = {
     "(" "," ")" => Expr::Dummy,
     "(" Ident "->" PatList ")" => Expr::Dummy,
 
-    r"\\" r"[a-zA-Z_.][.a-zA-Z_0-9']*" Expr* "->" Expr => Expr::Lambda,
+    r"\\" r"[a-zA-Z_.][.a-zA-Z_0-9':=]*" Expr* "->" Expr => Expr::Lambda,
 
     "`" <Ident> "`" => Expr::Operator(<>.0),
-    "\\" => Expr::Operator(<>.to_string()),
-    ":" => Expr::Operator(<>.to_string()),
-    "." => Expr::Operator(<>.to_string()),
-    "/=" => Expr::Operator(<>.to_string()),
-    "==" => Expr::Operator(<>.to_string()),
-    ".." => Expr::Operator(<>.to_string()),
-    "++" => Expr::Operator(<>.to_string()),
+    <Ctor> => Expr::Operator(<>.0),
+    <Operator> => Expr::Operator(<>),
     "$" => Expr::Operator(<>.to_string()),
-    "&&" => Expr::Operator(<>.to_string()),
-    "||" => Expr::Operator(<>.to_string()),
-    "<" => Expr::Operator(<>.to_string()),
-    "<=" => Expr::Operator(<>.to_string()),
-    "<-" => Expr::Operator(<>.to_string()),
-    ">" => Expr::Operator(<>.to_string()),
-    ">=" => Expr::Operator(<>.to_string()),
-    "=<<" => Expr::Operator(<>.to_string()),
-    ".|." => Expr::Operator(<>.to_string()),
-    ">>=" => Expr::Operator(<>.to_string()),
-    "@" => Expr::Operator(<>.to_string()),
-    "*" => Expr::Operator(<>.to_string()),
-    "+" => Expr::Operator(<>.to_string()),
-    "-" => Expr::Operator(<>.to_string()),
-    "^" => Expr::Operator(<>.to_string()),
+    "==" => Expr::Operator(<>.to_string()),
+    r"\\\\" => Expr::Operator(<>.to_string()),
+
+    // these special operators should not be exprs:
     "::" => Expr::Operator(<>.to_string()),
-    ".&." => Expr::Operator(<>.to_string()),
+    "@" => Expr::Operator(<>.to_string()),
 
     "case" <e:ExprSpan> "of" "{" <s:Semi<Case>> "}" => Expr::Case(Box::new(e), s),
 
-    "let" "{" Semi<Statement> "}" => Expr::Let,
+    "let" "{" Semi<LetInner> "}" => Expr::Let,
 
-    "do" "{" <e:Semi<ExprSpan>>
-      <w:("where" "{" <Semi<Statement>> "}")?> "}" => Expr::Do(e, w),
+    "do" "{" <e:Semi<LetInner>> "}" => Expr::Do(vec![], None),
 
     "{" <Comma<(<Expr> "=" <ExprSpan>)>> "}" => Expr::Record(<>),
+};
+
+
+LetInner: () = {
+  "class" Type ("=>" Ident+)?
+    "where" "{" Semi<Statement> "}" => (),
+
+  "instance" FnDef
+    "where" "{" Semi<Statement> "}" => (),
+  "import" ImportList+ => (),
+
+  "data" <id:Ident+> "=" <p:Pipe<TypeGroup>>
+    <derives:("deriving" <ImportList>)?> =>
+      (),
+  "newtype" <id:Ident+> "=" <p:Type>
+    ("deriving" ImportList)? =>
+      (),
+
+  "type" <d:Ident> <args:TypeGroup?> "=" TypeGroup
+    ("where" "{" Semi<Statement> "}")? => (),
+
+  <ExprSpan> "=" <ExprSpan> => (),
+  <ExprSpan> "|" <ExprSpan> "=" <ExprSpan> ("where" "{" Semi<Statement> "}")? => (),
+  <ExprSpan> ("where" "{" <Semi<Statement>> "}")? => (), // TODO this should be associated with parent "do", not with its inner contents
+
+  "where" "{" <Semi<Statement>> "}" => (),
 };
 
 FnDef: Ty = {
@@ -158,13 +182,18 @@ Type: Ty = {
     <TypeSpan> => <>,
 };
 
+TypeRecord: () = {
+  <Ident> "::" <TypeGroup> => (),
+};
+
 TypeSub: Ty = {
     "!" <TypeSub> => Ty::Not(Box::new(<>)),
     "[" <Type> "]" => Ty::Brackets(Box::new(<>)),
     "(" <CommaDef<Type>> ")" => Ty::Tuple(<>),
     "(" ")" => Ty::EmptyParen,
-    "{" <Comma<(<Ident> "::" <FnDef>)>> "}" => Ty::RecordTODO,
+    "{" <Comma<TypeRecord>> "}" => Ty::RecordTODO,
     <Ident> => Ty::Ref(<>),
+    <Ctor> => Ty::Ref(<>),
 };
 
 TypeGroupInner: Ty = {
@@ -193,12 +222,22 @@ PatSub: Pat = {
     },
     "(" <i:Ident> "->" <s: PatSpan> ")" => Pat::Arrow(i, Box::new(s)),
     "(" ")" => Pat::EmptyParen,
+    "{" <Comma<PatRecord>> "}" => Pat::RecordTODO,
     <Ident> => Pat::Ref(<>),
+    <Ctor> => Pat::Ref(<>),
+    <Operator> => Pat::Ref(Ident(<>)),
     <Quote> => Pat::Str(<>),
     <Num> => Pat::Num(<>),
-    ":" => Pat::Dummy,
     "==" => Pat::Dummy,
     "@" => Pat::Dummy,
+
+    // HACK
+    "`" Ident "`" => Pat::Dummy,
+};
+
+PatRecord: () = {
+  <Ident> "=" <PatSpan> => (),
+  ".." => (), // RecordWildCards
 };
 
 // for matching (Ctor arg arg ...)
@@ -216,6 +255,8 @@ ImportList: Vec<Ident> = {
     "(" <a:Commaish<(<Ident> ("(" ".." ")")?)>> ")" => a,
     "(" ")" => vec![],
     <Ident> => vec![<>],
+
+    "(" "(<|>)" ")" => vec![], // ??? see DefTable.hs
 };
 
 pub Module: Module = {
@@ -234,6 +275,9 @@ Statement: Statement = {
     "where" "{" Semi<Statement> "}" => Statement::Instance,
   "import" ImportList+ => Statement::Import,
 
+  // TODO change data enum to support this
+  "data" <id:Ident+> => Statement::Class,
+
   "data" <id:Ident+> "=" <p:Pipe<TypeGroup>>
     <derives:("deriving" <ImportList>)?> =>
       Statement::Data(id[0].clone(), p, derives),
@@ -243,7 +287,7 @@ Statement: Statement = {
 
   <i:Ident> "::" <d:FnDef> => Statement::Prototype(i, vec![d]),
 
-  "type" <d:Ident> <args:TypeGroup?> "=" Expr+
+  "type" <d:Ident> <args:TypeGroup?> "=" TypeGroup
     ("where" "{" Semi<Statement> "}")? => Statement::Typedef(d),
 
   <args:PatList> ("|" Commaish<Expr> "=" Expr+)*

--- a/parser/src/util.rs
+++ b/parser/src/util.rs
@@ -64,6 +64,7 @@ fn code_error(code: &str, tok_pos: usize) {
     }
 }
 
+// Print out errors smartly
 pub fn print_parse_error(code: &str, err: &ParseError<usize, String, ()>) {
     match *err {
         ParseError::InvalidToken { location: loc } => {


### PR DESCRIPTION
This is some implicit bracket fixes and some missing operators to get C.lhs to parse fully.

The PR has a new "LetInner" AST node, but it should be removed—it's only to fix the bad way of handling the intermixing of Exprs and Statements in let blocks. I was under the impression they were different but it's worth actually looking into Haskell's parsing rules here.