### PR TITLE
Char literals

### DIFF
--- a/out/corrode.rs
+++ b/out/corrode.rs
@@ -456,7 +456,7 @@ mod Language_Rust_Corrode_C {
                     CStrConst, CString(str, False), _ => { return(Result, hashmap! {
                         "resultType" => IsArray(Rust.Immutable, (+(length(str), 1)), charType),
                         "resultMutable" => Rust.Immutable,
-                        "result" => Rust.Deref((Rust.Lit((Rust.LitByteStr((++(str, "N".to_string())))))))
+                        "result" => Rust.Deref((Rust.Lit((Rust.LitByteStr((++(str, "\u{0}".to_string())))))))
                         }) },
                     _ => { unimplemented(expr) },
                 } },
@@ -572,7 +572,7 @@ mod Language_Rust_Corrode_C {
     }
 
     fn noTranslation(node: node, msg: String) -> EnvMonad(s, a) {
-        throwE(concat(vec![show((posOf(node))), ": ".to_string(), msg, ":\\n".to_string(), render((nest(4, (pretty(node)))))]))
+        throwE(concat(vec![show((posOf(node))), ": ".to_string(), msg, ":\n".to_string(), render((nest(4, (pretty(node)))))]))
     }
 
     fn objectFromDesignators(__0: CType, __1: Vec<CDesignator>) -> EnvMonad(s, CurrentObject) {
@@ -713,13 +713,13 @@ mod Language_Rust_Corrode_C {
         match (__0) {
             IsBool => { Rust.TypeName("bool".to_string()) },
             IsInt(s, w) => { Rust.TypeName((:((match s {
-                                Signed => { "\"\"".to_string() },
-                                Unsigned => { "\"\"".to_string() },
+                                Signed => { 'i' },
+                                Unsigned => { 'u' },
                             }), (match w {
                                 BitWidth, b => { show(b) },
                                 WordWidth => { "size".to_string() },
                             })))) },
-            IsFloat(w) => { Rust.TypeName((:("\"\"".to_string(), show(w)))) },
+            IsFloat(w) => { Rust.TypeName((:('f', show(w)))) },
             IsVoid => { Rust.TypeName("::std::os::raw::c_void".to_string()) },
             IsFunc(retTy, args, variadic) => { Rust.TypeName(concat(vec!["unsafe extern fn(".to_string(), args', ")".to_string(), /=(if(retTy), ++(IsVoid(then, " -> ".to_string()), typename(retTy, else, "".to_string())))])) },
             IsPtr(mut, to) => { Let },

--- a/out/language_c.rs
+++ b/out/language_c.rs
@@ -851,7 +851,7 @@ mod Language_C_Data_Error {
     }
 
     fn internalErr(msg: String) -> a {
-        error((++(internalErrPrefix, ++("\\n".to_string(), ++(indentLines(msg), "\\n".to_string())))))
+        error((++(internalErrPrefix, ++("\n".to_string(), ++(indentLines(msg), "\n".to_string())))))
     }
 
     fn internalErrPrefix() -> String {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -13,6 +13,7 @@ pub enum Expr {
     Record(Vec<(Expr, Expr)>),
     Lambda,
     Str(String),
+    Char(String),
     Error,
     Dummy,
 }
@@ -79,6 +80,7 @@ pub enum Pat {
     Brackets(Vec<Pat>),
     RecordTODO,
     Str(String),
+    Char(String),
     Num(isize),
     EmptyParen,
     Dummy,

--- a/parser/src/calculator.lalrpop
+++ b/parser/src/calculator.lalrpop
@@ -60,13 +60,14 @@ CommaDef<T>: Vec<T> = { // (0)
 };
 
 Quote: String = {
-    // r#"'\\["]'"# => (),
-
-    r#"'[^']'"# => {
+    r#""[^"]*""# => {
       let a = <>;
       a[1..a.len()-1].to_string()
-    },
-    r#""[^"]*""# => {
+    }
+};
+
+SingleQuote: String = {
+    r"'[^']*'" => {
       let a = <>;
       a[1..a.len()-1].to_string()
     }
@@ -110,6 +111,7 @@ ExprSpan: Expr = {
 
 Expr: Expr = {
     Quote => Expr::Str(<>),
+    SingleQuote => Expr::Char(<>),
     <Ident> => Expr::Ref(<>),
     Num => Expr::Number(<>),
 
@@ -227,6 +229,7 @@ PatSub: Pat = {
     <Ctor> => Pat::Ref(<>),
     <Operator> => Pat::Ref(Ident(<>)),
     <Quote> => Pat::Str(<>),
+    <SingleQuote> => Pat::Char(<>),
     <Num> => Pat::Num(<>),
     "==" => Pat::Dummy,
     "@" => Pat::Dummy,


### PR DESCRIPTION
Aside: for some reason (probably shared code with char literals) Rust likes to escape `'`s when debug printing a string...

`println!("{:?}", "> ' <")` becomes `"> \' <"`. Confused me for a while!